### PR TITLE
Fix build by upgrading tokio-io dependency to tokio-io 0.1.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 
 [dependencies]
 futures = "0.1"
-tokio-io = "0.1"
+tokio-io = "0.1.3"
 tokio-timer = "0.1"
 bytes = "0.4"
 http = { git = "https://github.com/carllerche/http", branch = "uri-try-from-parts" }
@@ -34,6 +34,3 @@ openssl = { version = "0.9.14", "features" = ["v102"] }
 tokio-openssl = "0.1.3"
 env_logger = "0.4.3"
 io-dump = { git = "https://github.com/carllerche/io-dump" }
-
-[replace]
-"tokio-io:0.1.2" = { git = "https://github.com/tokio-rs/tokio-io" }


### PR DESCRIPTION
tokio-io 0.1.3 has been published so the "replace" for tokio-io 0.1.2
is no longer useful and it breaks the build with some (but apparently
not all) versions of Cargo.

Update the dependency to tokio-io 0.1.3 since that is the version
that's what's been verified to work.