### PR TITLE
Switch Akamai example from rust-openssl to Rustls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ serde_json = "1.0.0"
 
 # Akamai example
 tokio-core = "0.1"
-openssl = { version = "0.9.14", "features" = ["v102"] }
-tokio-openssl = "0.1.3"
 env_logger = "0.4.3"
 io-dump = { git = "https://github.com/carllerche/io-dump" }
+rustls = "0.10.0"
+tokio-rustls = "0.3.1"
+webpki-roots = "0.12.0"


### PR DESCRIPTION
With this change, h2 can build and run without any manual configuration
steps for -msvc targets. Previously manual installation of OpenSSL
libraries was required.