### PR TITLE
remove possibly sensitive data from default Debug output

### DIFF
--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -1,7 +1,8 @@
 use frame::{util, Frame, Head, Error, StreamId, Kind};
 use bytes::{BufMut, Bytes, Buf};
 
-#[derive(Debug)]
+use std::fmt;
+
 pub struct Data<T = Bytes> {
     stream_id: StreamId,
     data: T,
@@ -109,6 +110,17 @@ impl<T: Buf> Data<T> {
 impl<T> From<Data<T>> for Frame<T> {
     fn from(src: Data<T>) -> Self {
         Frame::Data(src)
+    }
+}
+
+impl<T> fmt::Debug for Data<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Data")
+            .field("stream_id", &self.stream_id)
+            .field("flags", &self.flags)
+            .field("pad_len", &self.pad_len)
+            // `data` purposefully excluded
+            .finish()
     }
 }
 

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -17,7 +17,6 @@ use std::io::Cursor;
 /// Header frame
 ///
 /// This could be either a request or a response.
-#[derive(Debug)]
 pub struct Headers {
     /// The ID of the stream with which this frame is associated.
     stream_id: StreamId,
@@ -340,6 +339,17 @@ impl Headers {
 impl<T> From<Headers> for Frame<T> {
     fn from(src: Headers) -> Self {
         Frame::Headers(src)
+    }
+}
+
+impl fmt::Debug for Headers {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Headers")
+            .field("stream_id", &self.stream_id)
+            .field("stream_dep", &self.stream_dep)
+            .field("flags", &self.flags)
+            // `fields` and `pseudo` purposefully not included
+            .finish()
     }
 }
 


### PR DESCRIPTION
I noticed logs included bytes from data and headers frames. It's possible for these things to include secrets or sensitive data, so it should probably not be too easy to accidentally get that data stored in a logfile somewhere.