### PR TITLE
Validate received content-length header

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -266,6 +266,10 @@ impl Headers {
         (self.pseudo, self.fields)
     }
 
+    pub fn fields(&self) -> &HeaderMap {
+        &self.fields
+    }
+
     pub fn into_fields(self) -> HeaderMap {
         self.fields
     }


### PR DESCRIPTION
If a content-length header is provided, the value should match the sum
of all data frame lengths. If there is a mismatch, then the stream is
reset.