### PR TITLE
Unbox server handshake future

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -9,12 +9,11 @@ pub(crate) use self::connection::Connection;
 pub(crate) use self::error::Error;
 pub(crate) use self::peer::Peer;
 pub(crate) use self::streams::{Key as StreamKey, StreamRef, Streams};
-
+pub(crate) use self::streams::Prioritized;
 use codec::Codec;
 
 use self::ping_pong::PingPong;
 use self::settings::Settings;
-use self::streams::Prioritized;
 
 use frame::{self, Frame};
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -118,10 +118,18 @@ where
         Handshake { settings, state }
     }
 
+    /// Sets the target window size for the whole connection.
+    ///
+    /// Default in HTTP2 is 65_535.
+    pub fn set_target_window_size(&mut self, size: u32) {
+        assert!(size <= proto::MAX_WINDOW_SIZE);
+        self.connection.set_target_window_size(size);
+    }
+
     /// Returns `Ready` when the underlying connection has closed.
     pub fn poll_close(&mut self) -> Poll<(), ::Error> {
         self.connection.poll().map_err(Into::into)
-    }
+}
 }
 
 impl<T, B> futures::Stream for Server<T, B>

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,10 +115,10 @@ where
             .expect("invalid SETTINGS frame");
 
         let to_server: fn(Codec<T, Prioritized<B::Buf>>) -> Server<T, B> =
-        |codec| {
-            let connection = Connection::new(codec);
-            Server { connection }
-        };
+            |codec| {
+                let connection = Connection::new(codec);
+                Server { connection }
+            };
 
         // Flush pending settings frame and then wait for the client preface
         let handshake = Flush::new(codec)

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,6 @@ use bytes::{Buf, Bytes, IntoBuf};
 use futures::{self, Async, Future, Poll};
 use http::{HeaderMap, Request, Response};
 use tokio_io::{AsyncRead, AsyncWrite};
-use bytes::{Bytes, Buf, IntoBuf};
 use std::fmt;
 
 /// In progress H2 connection binding

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,7 +115,7 @@ where
 
         let to_server: fn(Codec<T, Prioritized<B::Buf>>) -> Server<T, B> =
             |codec| {
-                let connection = Connection::new(codec);
+                let connection = Connection::new(codec, &settings, 2.into());
                 Server { connection }
             };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -482,11 +482,11 @@ impl<T, B: IntoBuf> Future for Handshake<T, B>
             (|$option:ident, $codec:ident| $body:block) => {{
                 let mut state = $option
                     .take()
-                    .expect("Handshaking::poll: state option already taken!");
+                    .expect("Handshake::poll(): state option already taken!");
                 match state.poll() {
                     Ok(Async::Ready($codec)) => {
                         trace!(
-                            "    --> {}.poll(); Ok(Async::Ready({}))",
+                            "Handshake::poll(); {}.poll()=Ok(Async::Ready({}))",
                             stringify!($option),
                             stringify!($codec)
                         );
@@ -494,14 +494,14 @@ impl<T, B: IntoBuf> Future for Handshake<T, B>
                     },
                     Ok(Async::NotReady) => {
                         trace!(
-                            "     --> {}.poll(); Ok(Async::NotReady)",
+                            "Handshake::poll(); {}.poll()=Ok(Async::NotReady)",
                             stringify!($option)
                         );
                         Handshaking::from(state)
                     }
                     Err(e) => {
                         warn!(
-                            "    --> {}.poll(); Err({})",
+                            "Handshake::poll(); {}.poll()=Err({})",
                             stringify!($option),
                             e
                         );


### PR DESCRIPTION
Server-side version of #42. I've rewritten `server::Handshake` to store the inner future with a named type, rather than as a `Box<Future>`. In addition to removing a `Box`, this also means that the `'static` lifetime bounds on the type parameters `T` and `B` can be removed.

The type of the server handshake future is somewhat more complex than the client-side handshake future. Note also that I've had to re-export `proto::streams::Prioritized` as `pub(crate)` from `proto`, as it appears in the type of the handshake future.

I've ran the tests against this branch and everything passes. Since no new functionality was added, I haven't added any additional tests.