### PR TITLE
Remove AsyncRead + AsyncWrite constraint from h2::Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -24,7 +24,7 @@ pub struct Handshake<T: AsyncRead + AsyncWrite, B: IntoBuf = Bytes> {
 }
 
 /// Marker type indicating a client peer
-pub struct Client<T: AsyncRead + AsyncWrite, B: IntoBuf> {
+pub struct Client<T, B: IntoBuf> {
     connection: Connection<T, Peer, B>,
 }
 


### PR DESCRIPTION
This type constraint shouldn't be necessary, and is cumbersome.