### PR TITLE
Make Codec max frame length configurable

### DIFF
--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -219,6 +219,26 @@ impl<T> FramedRead<T> {
     pub fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()
     }
+
+    /// Returns the current max frame setting
+    ///
+    /// This is the largest size this codec will accept from the wire. Larger
+    /// frames will be rejected.
+    #[inline]
+    pub fn max_frame_length(&self) -> usize {
+        self.inner.max_frame_length()
+    }
+
+    /// Updates the max frame setting.
+    ///
+    /// The change takes effect the next time a frame is decoded. In other
+    /// words, if a frame is currently in process of being decoded with a frame
+    /// size greater than `val` but less than the max frame length in effect
+    /// before calling this function, then the frame will be allowed.
+    #[inline]
+    pub fn set_max_frame_length(&mut self, val: usize) {
+        self.inner.set_max_frame_length(val)
+    }
 }
 
 impl<T> Stream for FramedRead<T>

--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -220,23 +220,15 @@ impl<T> FramedRead<T> {
         self.inner.get_mut()
     }
 
-    /// Returns the current max frame setting
-    ///
-    /// This is the largest size this codec will accept from the wire. Larger
-    /// frames will be rejected.
+    /// Returns the current max frame size setting
     #[inline]
-    pub fn max_frame_length(&self) -> usize {
+    pub fn max_frame_size(&self) -> usize {
         self.inner.max_frame_length()
     }
 
-    /// Updates the max frame setting.
-    ///
-    /// The change takes effect the next time a frame is decoded. In other
-    /// words, if a frame is currently in process of being decoded with a frame
-    /// size greater than `val` but less than the max frame length in effect
-    /// before calling this function, then the frame will be allowed.
+    /// Updates the max frame size setting.
     #[inline]
-    pub fn set_max_frame_length(&mut self, val: usize) {
+    pub fn set_max_frame_size(&mut self, val: usize) {
         self.inner.set_max_frame_length(val)
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -30,11 +30,11 @@ impl<T, B> Codec<T, B>
     /// Returns a new `Codec` with the default max frame size
     #[inline]
     pub fn new(io: T) -> Self {
-        Self::with_max_frame_length(io, frame::DEFAULT_MAX_FRAME_SIZE as usize)
+        Self::with_max_frame_size(io, frame::DEFAULT_MAX_FRAME_SIZE as usize)
     }
 
-    /// Returns a new `Codec` with the given maximum frame length
-    pub fn with_max_frame_length(io: T, max_frame_length: usize) -> Self {
+    /// Returns a new `Codec` with the given maximum frame size
+    pub fn with_max_frame_size(io: T, max_frame_size: usize) -> Self {
         // Wrap with writer
         let framed_write = FramedWrite::new(io);
 
@@ -44,38 +44,39 @@ impl<T, B> Codec<T, B>
             .length_field_length(3)
             .length_adjustment(9)
             .num_skip(0) // Don't skip the header
-            .max_frame_length(max_frame_length)
+            .max_frame_length(max_frame_size)
             .new_read(framed_write);
 
         let inner = FramedRead::new(delimited);
 
         Codec { inner }
     }
+}
 
-    /// Updates the max frame setting.
+impl<T, B> Codec<T, B> {
+
+    /// Updates the max received frame size.
     ///
     /// The change takes effect the next time a frame is decoded. In other
     /// words, if a frame is currently in process of being decoded with a frame
-    /// size greater than `val` but less than the max frame length in effect
+    /// size greater than `val` but less than the max frame size in effect
     /// before calling this function, then the frame will be allowed.
     #[inline]
-    pub fn set_max_frame_length(&mut self, val: usize) {
-        // TODO: should probably make some assertions about max frame length...
-        self.inner.set_max_frame_length(val)
+    pub fn set_max_recv_frame_size(&mut self, val: usize) {
+        // TODO: should probably make some assertions about max frame size...
+        self.inner.set_max_frame_size(val)
 
     }
 
-    /// Returns the current max frame setting
+    /// Returns the current max received frame size setting.
     ///
     /// This is the largest size this codec will accept from the wire. Larger
     /// frames will be rejected.
     #[inline]
-    pub fn max_frame_length(&self) -> usize {
-        self.inner.max_frame_length()
+    pub fn max_recv_frame_size(&self) -> usize {
+        self.inner.max_frame_size()
     }
-}
 
-impl<T, B> Codec<T, B> {
     /// Returns the max frame size that can be sent to the peer.
     pub fn max_send_frame_size(&self) -> usize {
         self.inner.get_ref().max_frame_size()

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -30,11 +30,14 @@ impl<T, B> Codec<T, B>
     /// Returns a new `Codec` with the default max frame size
     #[inline]
     pub fn new(io: T) -> Self {
-        Self::with_max_frame_size(io, frame::DEFAULT_MAX_FRAME_SIZE as usize)
+        Self::with_max_recv_frame_size(
+            io,
+            frame::DEFAULT_MAX_FRAME_SIZE as usize
+        )
     }
 
     /// Returns a new `Codec` with the given maximum frame size
-    pub fn with_max_frame_size(io: T, max_frame_size: usize) -> Self {
+    pub fn with_max_recv_frame_size(io: T, max_frame_size: usize) -> Self {
         // Wrap with writer
         let framed_write = FramedWrite::new(io);
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -27,7 +27,14 @@ impl<T, B> Codec<T, B>
     where T: AsyncRead + AsyncWrite,
           B: Buf,
 {
+    /// Returns a new `Codec` with the default max frame size
+    #[inline]
     pub fn new(io: T) -> Self {
+        Self::with_max_frame_length(io, frame::DEFAULT_MAX_FRAME_SIZE as usize)
+    }
+
+    /// Returns a new `Codec` with the given maximum frame length
+    pub fn with_max_frame_length(io: T, max_frame_length: usize) -> Self {
         // Wrap with writer
         let framed_write = FramedWrite::new(io);
 
@@ -37,14 +44,34 @@ impl<T, B> Codec<T, B>
             .length_field_length(3)
             .length_adjustment(9)
             .num_skip(0) // Don't skip the header
-            // TODO: make this configurable and allow it to be changed during
-            // runtime.
-            .max_frame_length(frame::DEFAULT_MAX_FRAME_SIZE as usize)
+            .max_frame_length(max_frame_length)
             .new_read(framed_write);
 
         let inner = FramedRead::new(delimited);
 
         Codec { inner }
+    }
+
+    /// Updates the max frame setting.
+    ///
+    /// The change takes effect the next time a frame is decoded. In other
+    /// words, if a frame is currently in process of being decoded with a frame
+    /// size greater than `val` but less than the max frame length in effect
+    /// before calling this function, then the frame will be allowed.
+    #[inline]
+    pub fn set_max_frame_length(&mut self, val: usize) {
+        // TODO: should probably make some assertions about max frame length...
+        self.inner.set_max_frame_length(val)
+
+    }
+
+    /// Returns the current max frame setting
+    ///
+    /// This is the largest size this codec will accept from the wire. Larger
+    /// frames will be rejected.
+    #[inline]
+    pub fn max_frame_length(&self) -> usize {
+        self.inner.max_frame_length()
     }
 }
 

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -2,6 +2,8 @@
 extern crate h2_test_support;
 use h2_test_support::prelude::*;
 
+use std::error::Error;
+
 #[test]
 fn read_none() {
     let mut codec = Codec::from(
@@ -110,4 +112,23 @@ fn read_headers_with_pseudo() {
 
 #[test]
 fn read_headers_empty_payload() {
+}
+
+#[test]
+fn update_max_frame_len_at_rest() {
+    // TODO: add test for updating max frame length in flight as well?
+    let mut codec = raw_codec! {
+        read => [
+            0, 0, 5, 0, 0, 0, 0, 0, 1,
+            "hello",
+            "world",
+        ];
+    };
+
+    assert_eq!(poll_data!(codec).payload(), &b"hello"[..]);
+
+    codec.set_max_frame_length(2);
+
+    assert_eq!(codec.max_frame_length(), 2);
+    assert_eq!(codec.poll().unwrap_err().description(), "frame size too big");
 }

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -127,8 +127,8 @@ fn update_max_frame_len_at_rest() {
 
     assert_eq!(poll_data!(codec).payload(), &b"hello"[..]);
 
-    codec.set_max_frame_size(2);
+    codec.set_max_recv_frame_size(2);
 
-    assert_eq!(codec.max_frame_size(), 2);
+    assert_eq!(codec.max_recv_frame_size(), 2);
     assert_eq!(codec.poll().unwrap_err().description(), "frame size too big");
 }

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -127,8 +127,8 @@ fn update_max_frame_len_at_rest() {
 
     assert_eq!(poll_data!(codec).payload(), &b"hello"[..]);
 
-    codec.set_max_frame_length(2);
+    codec.set_max_frame_size(2);
 
-    assert_eq!(codec.max_frame_length(), 2);
+    assert_eq!(codec.max_frame_size(), 2);
     assert_eq!(codec.poll().unwrap_err().description(), "frame size too big");
 }


### PR DESCRIPTION
There was a TODO comment in `Codec` where the maximum frame length was set saying "make this configurable and allow it to be changed during runtime."

I've added methods `get_max_frame_length` and `set_max_frame_length` on `codec::FramedRead` that wrap the underlying methods of the same name on `tokio_io::length_delimited::FramedRead`, and the same methods to `Codec` wrapping the methods on `codec::FramedRead`.

Added a unit test for this, based on the `update_max_frame_len_at_rest()` test in `tokio_io`. Would like to add a test for updating the max frame length when frames are in flight as well, but it'll take a little more work to mock and given that we're just farming this out to `tokio_io`, it'll _probably_ be fine, right?