### PR TITLE
Fix some flow control bugs

### DIFF
--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -238,11 +238,10 @@ fn send_data_receive_window_update() {
         });
 
     let mock = mock.assert_client_handshake().unwrap()
-        .and_then(|(_, mock)| {
-            mock.into_future().unwrap()
-        })
+        .and_then(|(_, mock)| mock.into_future().unwrap())
         .and_then(|(frame, mock)| {
-            let _ = assert_headers!(frame.unwrap());
+            let request = assert_headers!(frame.unwrap());
+            assert!(!request.is_end_stream());
             mock.into_future().unwrap()
         })
         .and_then(|(frame, mut mock)| {


### PR DESCRIPTION
When a stream is closed, connection level capacity should be released
back to the connection and then assigned to other streams waiting for
capacity.