### PR TITLE
check for StreamId overflow

### DIFF
--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -37,6 +37,10 @@ pub enum UserError {
 
     /// The released capacity is larger than claimed capacity.
     ReleaseCapacityTooBig,
+    /// The stream ID space is overflowed.
+    ///
+    /// A new connection is needed.
+    OverflowedStreamId,
 }
 
 // ===== impl RecvError =====
@@ -112,6 +116,7 @@ impl error::Error for UserError {
             PayloadTooBig => "payload too big",
             Rejected => "rejected",
             ReleaseCapacityTooBig => "release capacity too big",
+            OverflowedStreamId => "stream ID overflowed",
         }
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -48,7 +48,7 @@ pub use self::priority::{Priority, StreamDependency};
 pub use self::reason::Reason;
 pub use self::reset::Reset;
 pub use self::settings::Settings;
-pub use self::stream_id::StreamId;
+pub use self::stream_id::{StreamId, StreamIdOverflow};
 pub use self::window_update::WindowUpdate;
 
 // Re-export some constants

--- a/src/frame/stream_id.rs
+++ b/src/frame/stream_id.rs
@@ -4,9 +4,16 @@ use std::u32;
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct StreamId(u32);
 
+#[derive(Debug, Copy, Clone)]
+pub struct StreamIdOverflow;
+
 const STREAM_ID_MASK: u32 = 1 << 31;
 
 impl StreamId {
+    pub const ZERO: StreamId = StreamId(0);
+
+    pub const MAX: StreamId = StreamId(u32::MAX >> 1);
+
     /// Parse the stream ID
     #[inline]
     pub fn parse(buf: &[u8]) -> (StreamId, bool) {
@@ -30,20 +37,20 @@ impl StreamId {
 
     #[inline]
     pub fn zero() -> StreamId {
-        StreamId(0)
-    }
-
-    #[inline]
-    pub fn max() -> StreamId {
-        StreamId(u32::MAX >> 1)
+        StreamId::ZERO
     }
 
     pub fn is_zero(&self) -> bool {
         self.0 == 0
     }
 
-    pub fn increment(&mut self) {
-        self.0 += 2;
+    pub fn next_id(&self) -> Result<StreamId, StreamIdOverflow> {
+        let next = self.0 + 2;
+        if next > StreamId::MAX.0 {
+            Err(StreamIdOverflow)
+        } else {
+            Ok(StreamId(next))
+        }
     }
 }
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -61,13 +61,14 @@ where
     pub fn new(
         codec: Codec<T, Prioritized<B::Buf>>,
         settings: &frame::Settings,
+        next_stream_id: frame::StreamId
     ) -> Connection<T, P, B> {
-        // TODO: Actually configure
         let streams = Streams::new(streams::Config {
             local_init_window_sz: settings
                 .initial_window_size()
                 .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
             local_max_initiated: None,
+            local_next_stream_id: next_stream_id,
             local_push_enabled: settings.is_push_enabled(),
             remote_init_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
             remote_max_initiated: None,

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -23,7 +23,7 @@ use self::store::{Entry, Store};
 use self::stream::Stream;
 
 use error::Reason::*;
-use frame::StreamId;
+use frame::{StreamId, StreamIdOverflow};
 use proto::*;
 
 use bytes::Bytes;
@@ -36,6 +36,9 @@ pub struct Config {
 
     /// Maximum number of locally initiated streams
     pub local_max_initiated: Option<usize>,
+
+    /// The stream ID to start the next local stream with
+    pub local_next_stream_id: StreamId,
 
     /// If the local peer is willing to receive push promises
     pub local_push_enabled: bool,

--- a/src/server.rs
+++ b/src/server.rs
@@ -106,7 +106,7 @@ where
         let handshake = Flush::new(codec)
             .and_then(ReadPreface::new)
             .map(move |codec| {
-                let connection = Connection::new(codec, &settings);
+                let connection = Connection::new(codec, &settings, 2.into());
                 Server {
                     connection,
                 }


### PR DESCRIPTION
Closes #48 

No tests... With #64, it'd be pretty easy to add a test to stream_states when a peer tries to open a new stream once the id space is at max. Adding a test that a `UserError` is returned will require adding some way to configure the next stream ID manually, or we'd have a test case submitting some 2 million requests...