### PR TITLE
Intial Client Configuration

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -48,7 +48,6 @@ impl<T> Client<T, Bytes>
 where
     T: AsyncRead + AsyncWrite,
 {
-
     /// Bind an H2 client connection.
     ///
     /// Returns a future which resolves to the connection value once the H2
@@ -69,8 +68,9 @@ impl Client<(), Bytes> {
 }
 
 impl<T, B> Client<T, B>
-where T: AsyncRead + AsyncWrite,
-      B: IntoBuf
+where
+    T: AsyncRead + AsyncWrite,
+    B: IntoBuf,
 {
     fn handshake2(io: T, settings: Settings) -> Handshake<T, B> {
         use tokio_io::io;
@@ -78,8 +78,7 @@ where T: AsyncRead + AsyncWrite,
         debug!("binding client connection");
 
         let msg: &'static [u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
-        let handshake = io::write_all(io, msg)
-            .map_err(::Error::from as _);
+        let handshake = io::write_all(io, msg).map_err(::Error::from as _);
 
         Handshake {
             inner: handshake,
@@ -179,8 +178,9 @@ impl Builder {
     /// It's important to note that this does not **flush** the outbound
     /// settings to the wire.
     pub fn handshake<T, B>(&self, io: T) -> Handshake<T, B>
-        where T: AsyncRead + AsyncWrite,
-              B: IntoBuf
+    where
+        T: AsyncRead + AsyncWrite,
+        B: IntoBuf,
     {
         Client::handshake2(io, self.settings.clone())
     }
@@ -204,8 +204,9 @@ where
         let mut codec = Codec::new(io);
 
         // Send initial settings frame
-        codec.buffer(self.settings.clone().into())
-           .expect("invalid SETTINGS frame");
+        codec
+            .buffer(self.settings.clone().into())
+            .expect("invalid SETTINGS frame");
 
         let connection = Connection::new(codec, &self.settings);
         Ok(Async::Ready(Client {

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -66,6 +66,10 @@ impl Settings {
         self.initial_window_size
     }
 
+    pub fn set_initial_window_size(&mut self, size: Option<u32>) {
+        self.initial_window_size = size;
+    }
+
     pub fn max_concurrent_streams(&self) -> Option<u32> {
         self.max_concurrent_streams
     }

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -58,7 +58,10 @@ where
     P: Peer,
     B: IntoBuf,
 {
-    pub fn new(codec: Codec<T, Prioritized<B::Buf>>, settings: &frame::Settings) -> Connection<T, P, B> {
+    pub fn new(
+        codec: Codec<T, Prioritized<B::Buf>>,
+        settings: &frame::Settings,
+    ) -> Connection<T, P, B> {
         // TODO: Actually configure
         let streams = Streams::new(streams::Config {
             max_remote_initiated: None,
@@ -68,7 +71,6 @@ where
                 .initial_window_size()
                 .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
         });
-
         Connection {
             state: State::Open,
             codec: codec,

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -58,13 +58,15 @@ where
     P: Peer,
     B: IntoBuf,
 {
-    pub fn new(codec: Codec<T, Prioritized<B::Buf>>) -> Connection<T, P, B> {
+    pub fn new(codec: Codec<T, Prioritized<B::Buf>>, settings: &frame::Settings) -> Connection<T, P, B> {
         // TODO: Actually configure
         let streams = Streams::new(streams::Config {
             max_remote_initiated: None,
             init_remote_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
             max_local_initiated: None,
-            init_local_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
+            init_local_window_sz: settings
+                .initial_window_size()
+                .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
         });
 
         Connection {

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -1,7 +1,7 @@
 use super::*;
 use {client, frame, proto, server};
 use codec::{RecvError, UserError};
-use frame::Reason;
+use frame::{Reason, DEFAULT_INITIAL_WINDOW_SIZE};
 use proto::*;
 
 use http::HeaderMap;
@@ -64,13 +64,14 @@ where
 
         let mut flow = FlowControl::new();
 
-        flow.inc_window(config.init_remote_window_sz)
-            .ok()
+        // connections always have the default window size, regardless of
+        // settings
+        flow.inc_window(DEFAULT_INITIAL_WINDOW_SIZE)
             .expect("invalid initial remote window size");
-        flow.assign_capacity(config.init_remote_window_sz);
+        flow.assign_capacity(DEFAULT_INITIAL_WINDOW_SIZE);
 
         Recv {
-            init_window_sz: config.init_remote_window_sz,
+            init_window_sz: config.init_local_window_sz,
             flow: flow,
             next_stream_id: next_stream_id.into(),
             pending_window_updates: store::Queue::new(),

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -314,14 +314,15 @@ impl State {
         }
     }
 
-    pub fn ensure_recv_open(&self) -> Result<(), proto::Error> {
+    pub fn ensure_recv_open(&self) -> Result<bool, proto::Error> {
         use std::io;
 
         // TODO: Is this correct?
         match self.inner {
             Closed(Some(Cause::Proto(reason))) => Err(proto::Error::Proto(reason)),
             Closed(Some(Cause::Io)) => Err(proto::Error::Io(io::ErrorKind::BrokenPipe.into())),
-            _ => Ok(()),
+            Closed(None) | HalfClosedRemote(..) => Ok(false),
+            _ => Ok(true),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use codec::{Codec, RecvError};
-use frame::{self, Reason, StreamId};
+use frame::{self, Reason, Settings, StreamId};
 use frame::Reason::*;
 use proto::{self, Connection, WindowSize};
 
@@ -82,19 +82,18 @@ where
         let mut codec = Codec::new(io);
 
         // Create the initial SETTINGS frame
-        let settings = frame::Settings::default();
+        let settings = Settings::default();
 
         // Send initial settings frame
         codec
             .buffer(settings.into())
-            .ok()
             .expect("invalid SETTINGS frame");
 
         // Flush pending settings frame and then wait for the client preface
         let handshake = Flush::new(codec)
             .and_then(ReadPreface::new)
             .map(move |codec| {
-                let connection = Connection::new(codec);
+                let connection = Connection::new(codec, &Settings::default());
                 Server {
                     connection,
                 }

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -225,17 +225,8 @@ fn recv_data_overflows_connection_window() {
             .and_then(|resp| {
                 assert_eq!(resp.status(), StatusCode::OK);
                 let body = resp.into_parts().1;
+                // FIXME: body stream should error also
                 body.concat2().unwrap()
-                /* FIXME: body stream should error also
-                        .then(|res| {
-                            let err = res.unwrap_err();
-                            assert_eq!(
-                                err.to_string(),
-                                "protocol error: flow-control protocol violated"
-                            );
-                            Ok::<(), ()>(())
-                        })
-                        */
             });
 
         // client should see a flow control error

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -225,8 +225,14 @@ fn recv_data_overflows_connection_window() {
             .and_then(|resp| {
                 assert_eq!(resp.status(), StatusCode::OK);
                 let body = resp.into_parts().1;
-                // FIXME: body stream should error also
-                body.concat2().unwrap()
+                body.concat2().then(|res| {
+                    let err = res.unwrap_err();
+                    assert_eq!(
+                        err.to_string(),
+                        "protocol error: flow-control protocol violated"
+                    );
+                    Ok::<(), ()>(())
+                })
             });
 
         // client should see a flow control error
@@ -244,10 +250,75 @@ fn recv_data_overflows_connection_window() {
 }
 
 #[test]
-#[ignore]
 fn recv_data_overflows_stream_window() {
     // this tests for when streams have smaller windows than their connection
+    let _ = ::env_logger::init();
+
+    let (io, srv) = mock::new();
+
+    let mock = srv.assert_client_handshake().unwrap()
+        .ignore_settings()
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos()
+        )
+        .send_frame(
+            frames::headers(1)
+                .response(200)
+        )
+        // fill the whole window
+        .send_frame(frames::data(1, vec![0u8; 16_384]))
+        // this frame overflows the window!
+        .send_frame(frames::data(1, &[0; 16][..]).eos())
+        // expecting goaway for the conn
+        // TODO: change to a RST_STREAM eventually
+        .recv_frame(frames::go_away(0).flow_control())
+        // close the connection
+        .map(drop);
+
+    let h2 = Client::builder()
+        .initial_window_size(16_384)
+        .handshake::<_, Bytes>(io)
+        .unwrap()
+        .and_then(|mut h2| {
+            let request = Request::builder()
+                .method(Method::GET)
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+
+            let req = h2.request(request, true)
+                .unwrap()
+                .unwrap()
+                .and_then(|resp| {
+                    assert_eq!(resp.status(), StatusCode::OK);
+                    let body = resp.into_parts().1;
+                    body.concat2().then(|res| {
+                        let err = res.unwrap_err();
+                        assert_eq!(
+                            err.to_string(),
+                            "protocol error: flow-control protocol violated"
+                        );
+                        Ok::<(), ()>(())
+                    })
+                });
+
+            // client should see a flow control error
+            let conn = h2.then(|res| {
+                let err = res.unwrap_err();
+                assert_eq!(
+                    err.to_string(),
+                    "protocol error: flow-control protocol violated"
+                );
+                Ok::<(), ()>(())
+            });
+            conn.unwrap().join(req)
+        });
+    h2.join(mock).wait().unwrap();
 }
+
+
 
 #[test]
 #[ignore]

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -62,10 +62,7 @@ fn send_recv_data() {
         ])
         .build();
 
-    let mut h2 = Client::builder()
-        .handshake(mock)
-        .wait()
-        .unwrap();
+    let mut h2 = Client::builder().handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -62,7 +62,10 @@ fn send_recv_data() {
         ])
         .build();
 
-    let mut h2 = Client::handshake2(mock).wait().unwrap();
+    let mut h2 = Client::builder()
+        .handshake(mock)
+        .wait()
+        .unwrap();
 
     let request = Request::builder()
         .method(Method::POST)

--- a/tests/support/src/mock.rs
+++ b/tests/support/src/mock.rs
@@ -326,6 +326,14 @@ pub trait HandleFutureExt {
         }
     }
 
+    fn ignore_settings(self) -> Box<Future<Item=Handle, Error=()>>
+        where Self: Sized + 'static,
+              Self: Future<Item=(frame::Settings, Handle)>,
+              Self::Error: fmt::Debug,
+    {
+        Box::new(self.map(|(_settings, handle)| handle).unwrap())
+    }
+
     fn recv_frame<T>(self, frame: T) -> RecvFrame<<Self as IntoRecvFrame>::Future>
         where Self: IntoRecvFrame + Sized,
               T: Into<Frame>,


### PR DESCRIPTION
Only started with a single setting, `initial_window_size`, instead of offer a bunch that aren't actually hooked up. As we want more (and we do), we will have to be sure that the setting actually does what it says.

While I was working on this, and coming up with a test case to make sure it worked, I ended up fixing some other things too... Oh well, they're broken into logical commits.

cc #40 (server config still missing)