### PR TITLE
Configure max frame size

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -170,6 +170,12 @@ impl Builder {
         self
     }
 
+    /// Set the max frame size of received frames.
+    pub fn max_frame_size(&mut self, max: u32) -> &mut Self {
+        self.settings.set_max_frame_size(Some(max));
+        self
+    }
+
     /// Bind an H2 client connection.
     ///
     /// Returns a future which resolves to the connection value once the H2
@@ -202,6 +208,10 @@ where
 
         // Create the codec
         let mut codec = Codec::new(io);
+
+        if let Some(max) = self.settings.max_frame_size() {
+            codec.set_max_recv_frame_size(max as usize);
+        }
 
         // Send initial settings frame
         codec

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -227,7 +227,7 @@ impl<T, B> FramedWrite<T, B> {
 
     /// Set the peer's max frame size.
     pub fn set_max_frame_size(&mut self, val: usize) {
-        assert!(val <= frame::MAX_MAX_FRAME_SIZE);
+        assert!(val <= frame::MAX_MAX_FRAME_SIZE as usize);
         self.max_frame_size = val as FrameSize;
     }
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -45,10 +45,12 @@ where
             .length_field_length(3)
             .length_adjustment(9)
             .num_skip(0) // Don't skip the header
-            .max_frame_length(max_frame_size)
             .new_read(framed_write);
 
-        let inner = FramedRead::new(delimited);
+        let mut inner = FramedRead::new(delimited);
+
+        // Use FramedRead's method since it checks the value is within range.
+        inner.set_max_frame_size(max_frame_size);
 
         Codec {
             inner,
@@ -66,7 +68,6 @@ impl<T, B> Codec<T, B> {
     #[cfg(feature = "unstable")]
     #[inline]
     pub fn set_max_recv_frame_size(&mut self, val: usize) {
-        // TODO: should probably make some assertions about max frame size...
         self.inner.set_max_frame_size(val)
     }
 

--- a/src/frame/reason.rs
+++ b/src/frame/reason.rs
@@ -33,7 +33,7 @@ impl Reason {
             FlowControlError => "flow-control protocol violated",
             SettingsTimeout => "settings ACK not received in timely manner",
             StreamClosed => "received frame when stream half-closed",
-            FrameSizeError => "frame sent with invalid size",
+            FrameSizeError => "frame with invalid size",
             RefusedStream => "refused stream before processing any application logic",
             Cancel => "stream no longer needed",
             CompressionError => "unable to maintain the header compression context",

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -46,7 +46,7 @@ pub const DEFAULT_MAX_FRAME_SIZE: FrameSize = 16_384;
 pub const MAX_INITIAL_WINDOW_SIZE: usize = (1 << 31) - 1;
 
 /// MAX_FRAME_SIZE upper bound
-pub const MAX_MAX_FRAME_SIZE: usize = (1 << 24) - 1;
+pub const MAX_MAX_FRAME_SIZE: FrameSize = (1 << 24) - 1;
 
 // ===== impl Settings =====
 
@@ -76,6 +76,13 @@ impl Settings {
 
     pub fn max_frame_size(&self) -> Option<u32> {
         self.max_frame_size
+    }
+
+    pub fn set_max_frame_size(&mut self, size: Option<u32>) {
+        if let Some(val) = size {
+            assert!(DEFAULT_MAX_FRAME_SIZE <= val && val <= MAX_MAX_FRAME_SIZE);
+        }
+        self.max_frame_size = size;
     }
 
     pub fn load(head: Head, payload: &[u8]) -> Result<Settings, Error> {
@@ -131,7 +138,7 @@ impl Settings {
                     settings.initial_window_size = Some(val);
                 },
                 Some(MaxFrameSize(val)) => {
-                    if val < DEFAULT_MAX_FRAME_SIZE || val as usize > MAX_MAX_FRAME_SIZE {
+                    if val < DEFAULT_MAX_FRAME_SIZE || val > MAX_MAX_FRAME_SIZE {
                         return Err(Error::InvalidSettingValue);
                     } else {
                         settings.max_frame_size = Some(val);

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,6 +93,10 @@ where
         // Create the codec
         let mut codec = Codec::new(io);
 
+        if let Some(max) = settings.max_frame_size() {
+            codec.set_max_recv_frame_size(max as usize);
+        }
+
         // Send initial settings frame
         codec
             .buffer(settings.clone().into())
@@ -180,13 +184,20 @@ impl Builder {
         self
     }
 
+    /// Set the max frame size of received frames.
+    pub fn max_frame_size(&mut self, max: u32) -> &mut Self {
+        self.settings.set_max_frame_size(Some(max));
+        self
+    }
+
     /// Bind an H2 server connection.
     ///
     /// Returns a future which resolves to the connection value once the H2
     /// handshake has been completed.
     pub fn handshake<T, B>(&self, io: T) -> Handshake<T, B>
-        where T: AsyncRead + AsyncWrite + 'static,
-              B: IntoBuf + 'static
+    where
+        T: AsyncRead + AsyncWrite + 'static,
+        B: IntoBuf + 'static,
     {
         Server::handshake2(io, self.settings.clone())
     }

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -110,22 +110,24 @@ fn read_headers_empty_payload() {}
 
 #[test]
 fn update_max_frame_len_at_rest() {
+    let _ = ::env_logger::init();
     // TODO: add test for updating max frame length in flight as well?
     let mut codec = raw_codec! {
         read => [
             0, 0, 5, 0, 0, 0, 0, 0, 1,
             "hello",
-            "world",
+            0, 64, 1, 0, 0, 0, 0, 0, 1,
+            vec![0; 16_385],
         ];
     };
 
     assert_eq!(poll_data!(codec).payload(), &b"hello"[..]);
 
-    codec.set_max_recv_frame_size(2);
+    codec.set_max_recv_frame_size(16_384);
 
-    assert_eq!(codec.max_recv_frame_size(), 2);
+    assert_eq!(codec.max_recv_frame_size(), 16_384);
     assert_eq!(
         codec.poll().unwrap_err().description(),
-        "frame size too big"
+        "frame with invalid size"
     );
 }

--- a/tests/support/src/frames.rs
+++ b/tests/support/src/frames.rs
@@ -146,6 +146,10 @@ impl Mock<frame::GoAway> {
     pub fn flow_control(self) -> Self {
         Mock(frame::GoAway::new(self.0.last_stream_id(), frame::Reason::FlowControlError))
     }
+
+    pub fn frame_size(self) -> Self {
+        Mock(frame::GoAway::new(self.0.last_stream_id(), frame::Reason::FrameSizeError))
+    }
 }
 
 impl From<Mock<frame::GoAway>> for SendFrame {

--- a/tests/support/src/mock.rs
+++ b/tests/support/src/mock.rs
@@ -26,7 +26,7 @@ pub struct Handle {
 }
 
 #[derive(Debug)]
-struct Pipe {
+pub struct Pipe {
     inner: Arc<Mutex<Inner>>,
 }
 
@@ -67,6 +67,11 @@ pub fn new() -> (Mock, Handle) {
 // ===== impl Handle =====
 
 impl Handle {
+    /// Get a mutable reference to inner Codec.
+    pub fn codec_mut(&mut self) -> &mut ::Codec<Pipe> {
+        &mut self.codec
+    }
+
     /// Send a frame
     pub fn send(&mut self, item: SendFrame) -> Result<(), SendError> {
         // Queue the frame
@@ -237,7 +242,7 @@ impl io::Write for Mock {
         let mut me = self.pipe.inner.lock().unwrap();
 
         if me.closed {
-            return Err(io::ErrorKind::BrokenPipe.into());
+            return Err(io::Error::new(io::ErrorKind::BrokenPipe, "mock closed"));
         }
 
         me.tx.extend(buf);

--- a/tests/support/src/raw.rs
+++ b/tests/support/src/raw.rs
@@ -44,3 +44,9 @@ impl<'a> Chunk for &'a str {
         dst.extend(self.as_bytes())
     }
 }
+
+impl Chunk for Vec<u8> {
+    fn push(&self, dst: &mut Vec<u8>) {
+        dst.extend(self.iter())
+    }
+}


### PR DESCRIPTION
- Adds `max_frame_size` to client and server builders
- Pushes max_frame_size into Codec
- Detects when the Codec triggers an error from a frame too big
- Sends a GOAWAY when FRAME_SIZE_ERROR is encountered reading a frame

Depends on #87 