### PR TITLE
add Client config to disable server push

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -176,6 +176,12 @@ impl Builder {
         self
     }
 
+    /// Enable or disable the server to send push promises.
+    pub fn enable_push(&mut self, enabled: bool) -> &mut Self {
+        self.settings.set_enable_push(enabled);
+        self
+    }
+
     /// Bind an H2 client connection.
     ///
     /// Returns a future which resolves to the connection value once the H2

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -127,8 +127,9 @@ where
                 }
             },
             Frame::PushPromise(v) => {
-                debug!("unimplemented PUSH_PROMISE write; frame={:?}", v);
-                unimplemented!();
+                if let Some(continuation) = v.encode(&mut self.hpack, self.buf.get_mut()) {
+                    self.next = Some(Next::Continuation(continuation));
+                }
             },
             Frame::Settings(v) => {
                 v.encode(self.buf.get_mut());

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -85,6 +85,14 @@ impl Settings {
         self.max_frame_size = size;
     }
 
+    pub fn is_push_enabled(&self) -> bool {
+        self.enable_push.unwrap_or(1) != 0
+    }
+
+    pub fn set_enable_push(&mut self, enable: bool) {
+        self.enable_push = Some(enable as u32);
+    }
+
     pub fn load(head: Head, payload: &[u8]) -> Result<Settings, Error> {
         use self::Setting::*;
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -64,12 +64,13 @@ where
     ) -> Connection<T, P, B> {
         // TODO: Actually configure
         let streams = Streams::new(streams::Config {
-            max_remote_initiated: None,
-            init_remote_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
-            max_local_initiated: None,
-            init_local_window_sz: settings
+            local_init_window_sz: settings
                 .initial_window_size()
                 .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
+            local_max_initiated: None,
+            local_push_enabled: settings.is_push_enabled(),
+            remote_init_window_sz: DEFAULT_INITIAL_WINDOW_SIZE,
+            remote_max_initiated: None,
         });
         Connection {
             state: State::Open,

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -34,9 +34,9 @@ where
     /// Create a new `Counts` using the provided configuration values.
     pub fn new(config: &Config) -> Self {
         Counts {
-            max_send_streams: config.max_local_initiated,
+            max_send_streams: config.local_max_initiated,
             num_send_streams: 0,
-            max_recv_streams: config.max_remote_initiated,
+            max_recv_streams: config.remote_max_initiated,
             num_recv_streams: 0,
             blocked_open: None,
             _p: PhantomData,

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -31,15 +31,18 @@ use http::{Request, Response};
 
 #[derive(Debug)]
 pub struct Config {
-    /// Maximum number of remote initiated streams
-    pub max_remote_initiated: Option<usize>,
-
-    /// Initial window size of remote initiated streams
-    pub init_remote_window_sz: WindowSize,
+    /// Initial window size of locally initiated streams
+    pub local_init_window_sz: WindowSize,
 
     /// Maximum number of locally initiated streams
-    pub max_local_initiated: Option<usize>,
+    pub local_max_initiated: Option<usize>,
 
-    /// Initial window size of locally initiated streams
-    pub init_local_window_sz: WindowSize,
+    /// If the local peer is willing to receive push promises
+    pub local_push_enabled: bool,
+
+    /// Initial window size of remote initiated streams
+    pub remote_init_window_sz: WindowSize,
+
+    /// Maximum number of remote initiated streams
+    pub remote_max_initiated: Option<usize>,
 }

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -49,11 +49,11 @@ where
     pub fn new(config: &Config) -> Prioritize<B, P> {
         let mut flow = FlowControl::new();
 
-        flow.inc_window(config.init_local_window_sz)
+        flow.inc_window(config.local_init_window_sz)
             .ok()
             .expect("invalid initial window size");
 
-        flow.assign_capacity(config.init_local_window_sz);
+        flow.assign_capacity(config.local_init_window_sz);
 
         trace!("Prioritize::new; flow={:?}", flow);
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -35,7 +35,7 @@ where
 
         Send {
             next_stream_id: next_stream_id.into(),
-            init_window_sz: config.init_local_window_sz,
+            init_window_sz: config.local_init_window_sz,
             prioritize: Prioritize::new(config),
         }
     }

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -285,6 +285,7 @@ impl State {
                 ..
             } => true,
             HalfClosedLocal(AwaitingHeaders) => true,
+            ReservedRemote => true,
             _ => false,
         }
     }

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -1,0 +1,109 @@
+extern crate h2_test_support;
+use h2_test_support::prelude::*;
+
+#[test]
+fn recv_push_works() {
+    // tests that by default, received push promises work
+    // TODO: once API exists, read the pushed response
+    let _ = ::env_logger::init();
+
+    let (io, srv) = mock::new();
+    let mock = srv.assert_client_handshake()
+        .unwrap()
+        .recv_settings()
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .send_frame(
+            frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
+        )
+        .send_frame(frames::headers(1).response(200).eos())
+        .send_frame(frames::headers(2).response(200).eos());
+
+    let h2 = Client::handshake(io).unwrap().and_then(|mut h2| {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://http2.akamai.com/")
+            .body(())
+            .unwrap();
+        let req = h2.request(request, true)
+            .unwrap()
+            .unwrap()
+            .and_then(|resp| {
+                assert_eq!(resp.status(), StatusCode::OK);
+                Ok(())
+            });
+
+        h2.drive(req)
+    });
+
+    h2.join(mock).wait().unwrap();
+}
+
+#[test]
+fn recv_push_when_push_disabled_is_conn_error() {
+    let _ = ::env_logger::init();
+
+    let (io, srv) = mock::new();
+    let mock = srv.assert_client_handshake()
+        .unwrap()
+        .ignore_settings()
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .send_frame(
+            frames::push_promise(1, 3).request("GET", "https://http2.akamai.com/style.css"),
+        )
+        .send_frame(frames::headers(1).response(200).eos())
+        .recv_frame(frames::go_away(0).protocol_error());
+
+    let h2 = Client::builder()
+        .enable_push(false)
+        .handshake::<_, Bytes>(io)
+        .unwrap()
+        .and_then(|mut h2| {
+            let request = Request::builder()
+                .method(Method::GET)
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+            let req = h2.request(request, true).unwrap().then(|res| {
+                let err = res.unwrap_err();
+                assert_eq!(
+                    err.to_string(),
+                    "protocol error: unspecific protocol error detected"
+                );
+                Ok::<(), ()>(())
+            });
+
+            // client should see a protocol error
+            let conn = h2.then(|res| {
+                let err = res.unwrap_err();
+                assert_eq!(
+                    err.to_string(),
+                    "protocol error: unspecific protocol error detected"
+                );
+                Ok::<(), ()>(())
+            });
+
+            conn.unwrap().join(req)
+        });
+
+    h2.join(mock).wait().unwrap();
+}
+
+#[test]
+#[ignore]
+fn recv_push_promise_with_unsafe_method_is_stream_error() {
+    // for instance, when :method = POST
+}
+
+#[test]
+#[ignore]
+fn recv_push_promise_with_wrong_authority_is_stream_error() {
+    // if server is foo.com, :authority = bar.com is stream error
+}


### PR DESCRIPTION
- Adds `Client::builder().enable_push(false)` to disable push
- Client sends a GO_AWAY if receiving a push when it's disabled