### PR TITLE
Derive Clone for Builder types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ pub struct Body<B: IntoBuf> {
 }
 
 /// Build a Client.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Builder {
     settings: Settings,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,7 +21,7 @@ pub struct Server<T, B: IntoBuf> {
 }
 
 /// Build a Server
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Builder {
     settings: Settings,
 }


### PR DESCRIPTION
It seems typical for something like a `tower::NewService` to hold a Builder, and it may need to clone a builder (i.e. out of `self` into a future).