### PR TITLE
Add `fixtures`, `examples`, and `util` to Codecov ignore list

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,9 @@ codecov:
 
 coverage:
   ignore:
+    - fixtures/.*
+    - examples/.*
+    - util/.*
     - tests/.*
   notify:
     slack:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ coverage:
     - examples/.*
     - util/.*
     - tests/.*
+    - src/hpack/test/.*
   notify:
     slack:
       default:


### PR DESCRIPTION
We probably don't care about covering code in these directories, so exclude them from test coverage.