### PR TITLE
Rename Client::request -> send_request

### DIFF
--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -75,7 +75,7 @@ pub fn main() {
                     .body(())
                     .unwrap();
 
-                let stream = h2.request(request, true).unwrap();
+                let stream = h2.send_request(request, true).unwrap();
 
                 let stream = stream.and_then(|response| {
                     let (_, body) = response.into_parts();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -70,7 +70,7 @@ pub fn main() {
             let mut trailers = HeaderMap::new();
             trailers.insert("zomg", "hello".parse().unwrap());
 
-            let mut stream = client.request(request, false).unwrap();
+            let mut stream = client.send_request(request, false).unwrap();
 
             // send trailers
             stream.send_trailers(trailers).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,7 +94,7 @@ where
     }
 
     /// Send a request on a new HTTP 2.0 stream
-    pub fn request(
+    pub fn send_request(
         &mut self,
         request: Request<()>,
         end_of_stream: bool,

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -48,7 +48,7 @@ fn recv_invalid_server_stream_id() {
         .unwrap();
 
     info!("sending request");
-    let stream = h2.request(request, true).unwrap();
+    let stream = h2.send_request(request, true).unwrap();
 
     // The connection errors
     assert!(h2.wait().is_err());

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -35,7 +35,7 @@ fn send_data_without_requesting_capacity() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.request(request, false).unwrap();
+    let mut stream = h2.send_request(request, false).unwrap();
 
     // The capacity should be immediately allocated
     assert_eq!(stream.capacity(), 0);
@@ -89,7 +89,7 @@ fn release_capacity_sends_window_update() {
             .body(())
             .unwrap();
 
-        let req = h2.request(request, true).unwrap()
+        let req = h2.send_request(request, true).unwrap()
                 .unwrap()
                 // Get the response
                 .and_then(|resp| {
@@ -152,7 +152,7 @@ fn release_capacity_of_small_amount_does_not_send_window_update() {
             .body(())
             .unwrap();
 
-        let req = h2.request(request, true).unwrap()
+        let req = h2.send_request(request, true).unwrap()
                 .unwrap()
                 // Get the response
                 .and_then(|resp| {
@@ -219,7 +219,7 @@ fn recv_data_overflows_connection_window() {
             .body(())
             .unwrap();
 
-        let req = h2.request(request, true)
+        let req = h2.send_request(request, true)
             .unwrap()
             .unwrap()
             .and_then(|resp| {
@@ -288,7 +288,7 @@ fn recv_data_overflows_stream_window() {
                 .body(())
                 .unwrap();
 
-            let req = h2.request(request, true)
+            let req = h2.send_request(request, true)
                 .unwrap()
                 .unwrap()
                 .and_then(|resp| {
@@ -341,7 +341,7 @@ fn stream_close_by_data_frame_releases_capacity() {
             .unwrap();
 
         // Send request
-        let mut s1 = h2.request(request, false).unwrap();
+        let mut s1 = h2.send_request(request, false).unwrap();
 
         // This effectively reserves the entire connection window
         s1.reserve_capacity(window_size);
@@ -357,7 +357,7 @@ fn stream_close_by_data_frame_releases_capacity() {
             .unwrap();
 
         // Create a second stream
-        let mut s2 = h2.request(request, false).unwrap();
+        let mut s2 = h2.send_request(request, false).unwrap();
 
         // Request capacity
         s2.reserve_capacity(5);
@@ -436,7 +436,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
             .unwrap();
 
         // Send request
-        let mut s1 = h2.request(request, false).unwrap();
+        let mut s1 = h2.send_request(request, false).unwrap();
 
         // This effectively reserves the entire connection window
         s1.reserve_capacity(window_size);
@@ -452,7 +452,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
             .unwrap();
 
         // Create a second stream
-        let mut s2 = h2.request(request, false).unwrap();
+        let mut s2 = h2.send_request(request, false).unwrap();
 
         // Request capacity
         s2.reserve_capacity(5);
@@ -558,7 +558,7 @@ fn recv_window_update_on_stream_closed_by_data_frame() {
                 .body(())
                 .unwrap();
 
-            let stream = h2.request(request, false).unwrap();
+            let stream = h2.send_request(request, false).unwrap();
 
             // Wait for the response
             h2.drive(GetResponse {
@@ -603,7 +603,7 @@ fn reserved_capacity_assigned_in_multi_window_updates() {
                 .body(())
                 .unwrap();
 
-            let mut stream = h2.request(request, false).unwrap();
+            let mut stream = h2.send_request(request, false).unwrap();
 
             // Consume the capacity
             let payload = vec![0; frame::DEFAULT_INITIAL_WINDOW_SIZE as usize];
@@ -731,13 +731,13 @@ fn connection_notified_on_released_capacity() {
             .body(())
             .unwrap();
 
-        tx.send(h2.request(request, true).unwrap()).unwrap();
+        tx.send(h2.send_request(request, true).unwrap()).unwrap();
 
         let request = Request::get("https://example.com/b")
             .body(())
             .unwrap();
 
-        tx.send(h2.request(request, true).unwrap()).unwrap();
+        tx.send(h2.send_request(request, true).unwrap()).unwrap();
 
         // Run the connection to completion
         h2.wait().unwrap();

--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -33,7 +33,7 @@ fn single_stream_send_large_body() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.request(request, false).unwrap();
+    let mut stream = h2.send_request(request, false).unwrap();
 
     // Reserve capacity to send the payload
     stream.reserve_capacity(payload.len());
@@ -87,7 +87,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.request(request, false).unwrap();
+    let mut stream = h2.send_request(request, false).unwrap();
 
     stream.reserve_capacity(payload.len());
 
@@ -152,7 +152,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.request(request, false).unwrap();
+    let mut stream = h2.send_request(request, false).unwrap();
 
     stream.reserve_capacity(payload.len());
 
@@ -185,7 +185,7 @@ fn send_data_receive_window_update() {
                 .unwrap();
 
             // Send request
-            let mut stream = h2.request(request, false).unwrap();
+            let mut stream = h2.send_request(request, false).unwrap();
 
             // Send data frame
             stream.send_data("hello".into(), false).unwrap();

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -28,7 +28,7 @@ fn recv_push_works() {
             .uri("https://http2.akamai.com/")
             .body(())
             .unwrap();
-        let req = h2.request(request, true)
+        let req = h2.send_request(request, true)
             .unwrap()
             .unwrap()
             .and_then(|resp| {
@@ -71,7 +71,7 @@ fn recv_push_when_push_disabled_is_conn_error() {
                 .uri("https://http2.akamai.com/")
                 .body(())
                 .unwrap();
-            let req = h2.request(request, true).unwrap().then(|res| {
+            let req = h2.send_request(request, true).unwrap().then(|res| {
                 let err = res.unwrap_err();
                 assert_eq!(
                     err.to_string(),

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -29,7 +29,7 @@ fn send_recv_headers_only() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.request(request, true).unwrap();
+    let mut stream = h2.send_request(request, true).unwrap();
 
     let resp = h2.run(poll_fn(|| stream.poll_response())).unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
@@ -71,7 +71,7 @@ fn send_recv_data() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.request(request, false).unwrap();
+    let mut stream = h2.send_request(request, false).unwrap();
 
     // Reserve send capacity
     stream.reserve_capacity(5);
@@ -128,7 +128,7 @@ fn send_headers_recv_data_single_frame() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.request(request, true).unwrap();
+    let mut stream = h2.send_request(request, true).unwrap();
 
     let resp = h2.run(poll_fn(|| stream.poll_response())).unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -160,7 +160,7 @@ fn closed_streams_are_released() {
             let request = Request::get("https://example.com/").body(()).unwrap();
 
             // Send request
-            let stream = h2.request(request, true).unwrap();
+            let stream = h2.send_request(request, true).unwrap();
             h2.drive(stream)
         })
         .and_then(|(h2, response)| {
@@ -207,7 +207,7 @@ fn errors_if_recv_frame_exceeds_max_frame_size() {
             .body(())
             .unwrap();
 
-        let req = h2.request(request, true)
+        let req = h2.send_request(request, true)
             .unwrap()
             .unwrap()
             .and_then(|resp| {
@@ -265,7 +265,7 @@ fn configure_max_frame_size() {
                 .body(())
                 .unwrap();
 
-            let req = h2.request(request, true)
+            let req = h2.send_request(request, true)
                 .unwrap()
                 .expect("response")
                 .and_then(|resp| {

--- a/tests/trailers.rs
+++ b/tests/trailers.rs
@@ -32,7 +32,7 @@ fn recv_trailers_only() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.request(request, true).unwrap();
+    let mut stream = h2.send_request(request, true).unwrap();
 
     let response = h2.run(poll_fn(|| stream.poll_response())).unwrap();
     assert_eq!(response.status(), StatusCode::OK);
@@ -80,7 +80,7 @@ fn send_trailers_immediately() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.request(request, false).unwrap();
+    let mut stream = h2.send_request(request, false).unwrap();
 
     let mut trailers = HeaderMap::new();
     trailers.insert("zomg", "hello".parse().unwrap());


### PR DESCRIPTION
All other fns have a send prefix.

Relates to #75