### PR TITLE
add test for client sending over max concurrent limit

### DIFF
--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -74,6 +74,10 @@ impl Settings {
         self.max_concurrent_streams
     }
 
+    pub fn set_max_concurrent_streams(&mut self, max: Option<u32>) {
+        self.max_concurrent_streams = max;
+    }
+
     pub fn max_frame_size(&self) -> Option<u32> {
         self.max_frame_size
     }

--- a/tests/support/src/frames.rs
+++ b/tests/support/src/frames.rs
@@ -58,6 +58,10 @@ pub fn reset<T>(id: T) -> Mock<frame::Reset>
     Mock(frame::Reset::new(id.into(), frame::Reason::NoError))
 }
 
+pub fn settings() -> Mock<frame::Settings> {
+    Mock(frame::Settings::default())
+}
+
 // === Generic helpers of all frame types
 
 pub struct Mock<T>(T);
@@ -227,6 +231,27 @@ impl Mock<frame::Reset> {
 impl From<Mock<frame::Reset>> for SendFrame {
     fn from(src: Mock<frame::Reset>) -> Self {
         Frame::Reset(src.0)
+    }
+}
+
+// ==== Settings helpers
+
+impl Mock<frame::Settings> {
+    pub fn max_concurrent_streams(mut self, max: u32) -> Self {
+        self.0.set_max_concurrent_streams(Some(max));
+        self
+    }
+}
+
+impl From<Mock<frame::Settings>> for frame::Settings {
+    fn from(src: Mock<frame::Settings>) -> Self {
+        src.0
+    }
+}
+
+impl From<Mock<frame::Settings>> for SendFrame {
+    fn from(src: Mock<frame::Settings>) -> Self {
+        Frame::Settings(src.0)
     }
 }
 

--- a/tests/support/src/mock.rs
+++ b/tests/support/src/mock.rs
@@ -113,9 +113,11 @@ impl Handle {
     }
 
     /// Perform the H2 handshake
-    pub fn assert_client_handshake_with_settings(mut self, settings: frame::Settings)
+    pub fn assert_client_handshake_with_settings<T>(mut self, settings: T)
         -> Box<Future<Item = (frame::Settings, Self), Error = h2::Error>>
+    where T: Into<frame::Settings>,
     {
+        let settings = settings.into();
         // Send a settings frame
         self.send(settings.into()).unwrap();
 


### PR DESCRIPTION
It actually already works, this just adds a test to prevent regressions.

Closes #27 