### PR TITLE
split Client into Connection and Client

### DIFF
--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -67,7 +67,7 @@ pub fn main() {
                 Client::handshake(tls)
             })
             .then(|res| {
-                let mut h2 = res.unwrap();
+                let (mut client, h2) = res.unwrap();
 
                 let request = Request::builder()
                     .method(Method::GET)
@@ -75,7 +75,7 @@ pub fn main() {
                     .body(())
                     .unwrap();
 
-                let stream = h2.send_request(request, true).unwrap();
+                let stream = client.send_request(request, true).unwrap();
 
                 let stream = stream.and_then(|response| {
                     let (_, body) = response.into_parts();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -58,7 +58,7 @@ pub fn main() {
         let tcp = io_dump::Dump::to_stdout(res.unwrap());
         Client::handshake(tcp)
     }).then(|res| {
-            let mut client = res.unwrap();
+            let (mut client, h2) = res.unwrap();
 
             println!("sending request");
 
@@ -75,8 +75,8 @@ pub fn main() {
             // send trailers
             stream.send_trailers(trailers).unwrap();
 
-            // Spawn a task to run the client...
-            handle.spawn(client.map_err(|e| println!("GOT ERR={:?}", e)));
+            // Spawn a task to run the conn...
+            handle.spawn(h2.map_err(|e| println!("GOT ERR={:?}", e)));
 
             stream
                 .and_then(|response| {

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -1,5 +1,5 @@
 use {client, frame, proto, server};
-use codec::{RecvError, SendError};
+use codec::RecvError;
 use frame::Reason;
 
 use frame::DEFAULT_INITIAL_WINDOW_SIZE;
@@ -7,7 +7,6 @@ use proto::*;
 
 use bytes::{Bytes, IntoBuf};
 use futures::Stream;
-use http::Request;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use std::marker::PhantomData;
@@ -249,18 +248,8 @@ where
     T: AsyncRead + AsyncWrite,
     B: IntoBuf,
 {
-    /// Returns `Ready` when new the connection is able to support a new request stream.
-    pub fn poll_send_request_ready(&mut self) -> Poll<(), ::Error> {
-        self.streams.poll_send_request_ready()
-    }
-
-    /// Initialize a new HTTP/2.0 stream and send the message.
-    pub fn send_request(
-        &mut self,
-        request: Request<()>,
-        end_of_stream: bool,
-    ) -> Result<StreamRef<B::Buf, client::Peer>, SendError> {
-        self.streams.send_request(request, end_of_stream)
+    pub(crate) fn streams(&self) -> &Streams<B::Buf, client::Peer> {
+        &self.streams
     }
 }
 
@@ -271,21 +260,5 @@ where
 {
     pub fn next_incoming(&mut self) -> Option<StreamRef<B::Buf, server::Peer>> {
         self.streams.next_incoming()
-    }
-}
-
-#[cfg(feature = "unstable")]
-impl<T, P, B> Connection<T, P, B>
-where
-    T: AsyncRead + AsyncWrite,
-    P: Peer,
-    B: IntoBuf,
-{
-    pub fn num_active_streams(&self) -> usize {
-        self.streams.num_active_streams()
-    }
-
-    pub fn num_wired_streams(&self) -> usize {
-        self.streams.num_wired_streams()
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -8,7 +8,7 @@ mod streams;
 pub(crate) use self::connection::Connection;
 pub(crate) use self::error::Error;
 pub(crate) use self::peer::Peer;
-pub(crate) use self::streams::{StreamRef, Streams};
+pub(crate) use self::streams::{Key as StreamKey, StreamRef, Streams};
 
 use codec::Codec;
 

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -1,5 +1,4 @@
 use super::*;
-use client;
 
 use std::marker::PhantomData;
 use std::usize;
@@ -10,19 +9,16 @@ where
     P: Peer,
 {
     /// Maximum number of locally initiated streams
-    max_send_streams: Option<usize>,
+    max_send_streams: usize,
 
     /// Current number of remote initiated streams
     num_send_streams: usize,
 
     /// Maximum number of remote initiated streams
-    max_recv_streams: Option<usize>,
+    max_recv_streams: usize,
 
     /// Current number of locally initiated streams
     num_recv_streams: usize,
-
-    /// Task awaiting notification to open a new stream.
-    blocked_open: Option<task::Task>,
 
     _p: PhantomData<P>,
 }
@@ -34,22 +30,17 @@ where
     /// Create a new `Counts` using the provided configuration values.
     pub fn new(config: &Config) -> Self {
         Counts {
-            max_send_streams: config.local_max_initiated,
+            max_send_streams: config.local_max_initiated.unwrap_or(usize::MAX),
             num_send_streams: 0,
-            max_recv_streams: config.remote_max_initiated,
+            max_recv_streams: config.remote_max_initiated.unwrap_or(usize::MAX),
             num_recv_streams: 0,
-            blocked_open: None,
             _p: PhantomData,
         }
     }
 
     /// Returns true if the receive stream concurrency can be incremented
     pub fn can_inc_num_recv_streams(&self) -> bool {
-        if let Some(max) = self.max_recv_streams {
-            max > self.num_recv_streams
-        } else {
-            true
-        }
+        self.max_recv_streams > self.num_recv_streams
     }
 
     /// Increments the number of concurrent receive streams.
@@ -66,11 +57,7 @@ where
 
     /// Returns true if the send stream concurrency can be incremented
     pub fn can_inc_num_send_streams(&self) -> bool {
-        if let Some(max) = self.max_send_streams {
-            max > self.num_send_streams
-        } else {
-            true
-        }
+        self.max_send_streams > self.num_send_streams
     }
 
     /// Increments the number of concurrent send streams.
@@ -87,7 +74,7 @@ where
 
     pub fn apply_remote_settings(&mut self, settings: &frame::Settings) {
         if let Some(val) = settings.max_concurrent_streams() {
-            self.max_send_streams = Some(val as usize);
+            self.max_send_streams = val as usize;
         }
     }
 
@@ -99,7 +86,7 @@ where
     where
         F: FnOnce(&mut Self, &mut store::Ptr<B, P>) -> U,
     {
-        let is_counted = stream.state.is_counted();
+        let is_counted = stream.is_counted();
 
         // Run the action
         let ret = f(self, &mut stream);
@@ -127,29 +114,10 @@ where
     }
 
     fn dec_num_streams(&mut self, id: StreamId) {
-        use std::usize;
-
         if P::is_local_init(id) {
             self.num_send_streams -= 1;
-
-            if self.num_send_streams < self.max_send_streams.unwrap_or(usize::MAX) {
-                if let Some(task) = self.blocked_open.take() {
-                    task.notify();
-                }
-            }
         } else {
             self.num_recv_streams -= 1;
         }
-    }
-}
-
-impl Counts<client::Peer> {
-    pub fn poll_open_ready(&mut self) -> Async<()> {
-        if !self.can_inc_num_send_streams() {
-            self.blocked_open = Some(task::current());
-            return Async::NotReady;
-        }
-
-        return Async::Ready(());
     }
 }

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -10,6 +10,7 @@ mod stream;
 mod streams;
 
 pub(crate) use self::prioritize::Prioritized;
+pub(crate) use self::store::Key;
 pub(crate) use self::streams::{StreamRef, Streams};
 
 use self::buffer::Buffer;

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -251,9 +251,8 @@ impl State {
         }
     }
 
-    /// Returns true if a stream with the current state counts against the
-    /// concurrency limit.
-    pub fn is_counted(&self) -> bool {
+    /// Returns true if a stream is open or half-closed.
+    pub fn is_at_least_half_open(&self) -> bool {
         match self.inner {
             Open {
                 ..

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -8,7 +8,9 @@ fn recv_single_ping() {
     let (m, mock) = mock::new();
 
     // Create the handshake
-    let h2 = Client::handshake(m).unwrap().and_then(|conn| conn.unwrap());
+    let h2 = Client::handshake(m)
+        .unwrap()
+        .and_then(|(_, conn)| conn.unwrap());
 
     let mock = mock.assert_client_handshake()
         .unwrap()

--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -25,7 +25,7 @@ fn single_stream_send_large_body() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let mut h2 = Client::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -33,7 +33,7 @@ fn single_stream_send_large_body() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.send_request(request, false).unwrap();
+    let mut stream = client.send_request(request, false).unwrap();
 
     // Reserve capacity to send the payload
     stream.reserve_capacity(payload.len());
@@ -79,7 +79,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let mut h2 = Client::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -87,7 +87,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.send_request(request, false).unwrap();
+    let mut stream = client.send_request(request, false).unwrap();
 
     stream.reserve_capacity(payload.len());
 
@@ -144,7 +144,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let mut h2 = Client::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -152,7 +152,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
         .body(())
         .unwrap();
 
-    let mut stream = h2.send_request(request, false).unwrap();
+    let mut stream = client.send_request(request, false).unwrap();
 
     stream.reserve_capacity(payload.len());
 
@@ -177,7 +177,7 @@ fn send_data_receive_window_update() {
 
     let h2 = Client::handshake(m)
         .unwrap()
-        .and_then(|mut h2| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -185,7 +185,7 @@ fn send_data_receive_window_update() {
                 .unwrap();
 
             // Send request
-            let mut stream = h2.send_request(request, false).unwrap();
+            let mut stream = client.send_request(request, false).unwrap();
 
             // Send data frame
             stream.send_data("hello".into(), false).unwrap();

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -20,13 +20,14 @@ fn recv_push_works() {
         .send_frame(frames::headers(1).response(200).eos())
         .send_frame(frames::headers(2).response(200).eos());
 
-    let h2 = Client::handshake(io).unwrap().and_then(|mut h2| {
+    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
             .body(())
             .unwrap();
-        let req = h2.send_request(request, true)
+        let req = client
+            .send_request(request, true)
             .unwrap()
             .unwrap()
             .and_then(|resp| {
@@ -61,13 +62,13 @@ fn recv_push_when_push_disabled_is_conn_error() {
         .enable_push(false)
         .handshake::<_, Bytes>(io)
         .unwrap()
-        .and_then(|mut h2| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://http2.akamai.com/")
                 .body(())
                 .unwrap();
-            let req = h2.send_request(request, true).unwrap().then(|res| {
+            let req = client.send_request(request, true).unwrap().then(|res| {
                 let err = res.unwrap_err();
                 assert_eq!(
                     err.to_string(),

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -480,7 +480,7 @@ where
             Async::Ready((frame, handle)) => (frame, handle),
             Async::NotReady => return Ok(Async::NotReady),
         };
-        assert_eq!(frame.unwrap(), self.frame);
+        assert_eq!(frame.unwrap(), self.frame, "recv_frame");
         Ok(Async::Ready(handle))
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,5 +1,11 @@
 //! Utilities to support tests.
 
+#[cfg(not(feature = "unstable"))]
+compile_error!(
+    "Tests depend on the 'unstable' feature on h2. \
+    Retry with `cargo test --features unstable`"
+);
+
 pub extern crate bytes;
 pub extern crate env_logger;
 pub extern crate futures;

--- a/tests/support/prelude.rs
+++ b/tests/support/prelude.rs
@@ -60,7 +60,7 @@ pub trait ClientExt {
     fn run<F: Future>(&mut self, f: F) -> Result<F::Item, F::Error>;
 }
 
-impl<T, B> ClientExt for Client<T, B>
+impl<T, B> ClientExt for client::Connection<T, B>
 where
     T: AsyncRead + AsyncWrite + 'static,
     B: IntoBuf + 'static,

--- a/tests/trailers.rs
+++ b/tests/trailers.rs
@@ -23,7 +23,7 @@ fn recv_trailers_only() {
         ])
         .build();
 
-    let mut h2 = Client::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -32,7 +32,7 @@ fn recv_trailers_only() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.send_request(request, true).unwrap();
+    let mut stream = client.send_request(request, true).unwrap();
 
     let response = h2.run(poll_fn(|| stream.poll_response())).unwrap();
     assert_eq!(response.status(), StatusCode::OK);
@@ -71,7 +71,7 @@ fn send_trailers_immediately() {
         ])
         .build();
 
-    let mut h2 = Client::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -80,7 +80,7 @@ fn send_trailers_immediately() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = h2.send_request(request, false).unwrap();
+    let mut stream = client.send_request(request, false).unwrap();
 
     let mut trailers = HeaderMap::new();
     trailers.insert("zomg", "hello".parse().unwrap());


### PR DESCRIPTION
The Connection type is a `Future` that drives all of the IO of the
client connection.

The Client type is separate, and is used to send requests into the
connection.

An unresolved question is what order of the tuple is better:

- `let (client, conn) = await!(handshake)?;`
- `let (conn, client) = await!(handshake)?;`