### PR TITLE
Rewrite flow control tests to use newer mock API

### DIFF
--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -400,11 +400,11 @@ fn stream_close_by_data_frame_releases_capacity() {
 #[test]
 fn stream_close_by_trailers_frame_releases_capacity() {
     let _ = ::env_logger::init();
-    let (m, mock) = mock::new();
+    let (io, srv) = mock::new();
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
 
-    let h2 = Client::handshake(m).unwrap().and_then(|mut h2| {
+    let h2 = Client::handshake(io).unwrap().and_then(|mut h2| {
         let request = Request::builder()
             .method(Method::POST)
             .uri("https://http2.akamai.com/")
@@ -451,44 +451,25 @@ fn stream_close_by_trailers_frame_releases_capacity() {
         h2.unwrap()
     });
 
-    let mock = mock.assert_client_handshake().unwrap()
+    let srv = srv.assert_client_handshake().unwrap()
         // Get the first frame
-        .and_then(|(_, mock)| mock.into_future().unwrap())
-        .and_then(|(frame, mock)| {
-            let request = assert_headers!(frame.unwrap());
+        .ignore_settings()
+        .recv_frame(
+            frames::headers(1)
+                .request("POST", "https://http2.akamai.com/")
+        )
+        .send_frame(frames::headers(1).response(200))
+        .recv_frame(
+            frames::headers(3)
+                .request("POST", "https://http2.akamai.com/")
+        )
+        .send_frame(frames::headers(3).response(200))
+        .recv_frame(frames::headers(1).eos())
+        .recv(frames::data(3, b"hello"[..]).eos())
+        .close()
+        ;
 
-            assert_eq!(request.stream_id(), 1);
-            assert!(!request.is_end_stream());
-
-            mock.into_future().unwrap()
-        })
-        .and_then(|(frame, mock)| {
-            let request = assert_headers!(frame.unwrap());
-
-            assert_eq!(request.stream_id(), 3);
-            assert!(!request.is_end_stream());
-
-            mock.into_future().unwrap()
-        })
-        .and_then(|(frame, mock)| {
-            let trailers = assert_headers!(frame.unwrap());
-
-            assert_eq!(trailers.stream_id(), 1);
-            assert!(trailers.is_end_stream());
-
-            mock.into_future().unwrap()
-        })
-        .and_then(|(frame, _)| {
-            let data = assert_data!(frame.unwrap());
-
-            assert_eq!(data.stream_id(), 3);
-            assert_eq!(data.payload(), "hello");
-            assert!(data.is_end_stream());
-
-            Ok(())
-        });
-
-    let _ = h2.join(mock).wait().unwrap();
+    let _ = h2.join(srv).wait().unwrap();
 }
 
 #[test]

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -257,7 +257,7 @@ fn recv_data_overflows_stream_window() {
     let (io, srv) = mock::new();
 
     let mock = srv.assert_client_handshake().unwrap()
-        .ignore_settings()
+        .recv_settings()
         .recv_frame(
             frames::headers(1)
                 .request("GET", "https://http2.akamai.com/")
@@ -381,19 +381,21 @@ fn stream_close_by_data_frame_releases_capacity() {
     });
 
     let srv = srv.assert_client_handshake().unwrap()
-        .ignore_settings()
+        .recv_settings()
         .recv_frame(
-            frames::headers(1).request("POST", "https://http2.akamai.com/")
+            frames::headers(1)
+                .request("POST", "https://http2.akamai.com/")
         )
         .send_frame(frames::headers(1).response(200))
         .recv_frame(
-            frames::headers(3).request("POST", "https://http2.akamai.com/")
+            frames::headers(3)
+                .request("POST", "https://http2.akamai.com/")
         )
         .send_frame(frames::headers(3).response(200))
         .recv_frame(frames::data(1, &b""[..]).eos())
         .recv_frame(frames::data(3, &b"hello"[..]).eos())
-        .close()
-        ;
+        .close();
+
     let _ = h2.join(srv).wait().unwrap();
 }
 
@@ -453,7 +455,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
 
     let srv = srv.assert_client_handshake().unwrap()
         // Get the first frame
-        .ignore_settings()
+        .recv_settings()
         .recv_frame(
             frames::headers(1)
                 .request("POST", "https://http2.akamai.com/")
@@ -465,9 +467,8 @@ fn stream_close_by_trailers_frame_releases_capacity() {
         )
         .send_frame(frames::headers(3).response(200))
         .recv_frame(frames::headers(1).eos())
-        .recv(frames::data(3, b"hello"[..]).eos())
-        .close()
-        ;
+        .recv_frame(frames::data(3, b"hello"[..]).eos())
+        .close();
 
     let _ = h2.join(srv).wait().unwrap();
 }

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -329,11 +329,11 @@ fn recv_window_update_causes_overflow() {
 #[test]
 fn stream_close_by_data_frame_releases_capacity() {
     let _ = ::env_logger::init();
-    let (m, mock) = mock::new();
+    let (io, srv) = mock::new();
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
 
-    let h2 = Client::handshake(m).unwrap().and_then(|mut h2| {
+    let h2 = Client::handshake(io).unwrap().and_then(|mut h2| {
         let request = Request::builder()
             .method(Method::POST)
             .uri("https://http2.akamai.com/")
@@ -380,45 +380,21 @@ fn stream_close_by_data_frame_releases_capacity() {
         h2.unwrap()
     });
 
-    let mock = mock.assert_client_handshake().unwrap()
-        // Get the first frame
-        .and_then(|(_, mock)| mock.into_future().unwrap())
-        .and_then(|(frame, mock)| {
-            let request = assert_headers!(frame.unwrap());
-
-            assert_eq!(request.stream_id(), 1);
-            assert!(!request.is_end_stream());
-
-            mock.into_future().unwrap()
-        })
-        .and_then(|(frame, mock)| {
-            let request = assert_headers!(frame.unwrap());
-
-            assert_eq!(request.stream_id(), 3);
-            assert!(!request.is_end_stream());
-
-            mock.into_future().unwrap()
-        })
-        .and_then(|(frame, mock)| {
-            let data = assert_data!(frame.unwrap());
-
-            assert_eq!(data.stream_id(), 1);
-            assert_eq!(data.payload().len(), 0);
-            assert!(data.is_end_stream());
-
-            mock.into_future().unwrap()
-        })
-        .and_then(|(frame, _)| {
-            let data = assert_data!(frame.unwrap());
-
-            assert_eq!(data.stream_id(), 3);
-            assert_eq!(data.payload(), "hello");
-            assert!(data.is_end_stream());
-
-            Ok(())
-        });
-
-    let _ = h2.join(mock).wait().unwrap();
+    let srv = srv.assert_client_handshake().unwrap()
+        .ignore_settings()
+        .recv_frame(
+            frames::headers(1).request("POST", "https://http2.akamai.com/")
+        )
+        .send_frame(frames::headers(1).response(200))
+        .recv_frame(
+            frames::headers(3).request("POST", "https://http2.akamai.com/")
+        )
+        .send_frame(frames::headers(3).response(200))
+        .recv_frame(frames::data(1, &b""[..]).eos())
+        .recv_frame(frames::data(3, &b"hello"[..]).eos())
+        .close()
+        ;
+    let _ = h2.join(srv).wait().unwrap();
 }
 
 #[test]

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -257,7 +257,7 @@ fn recv_data_overflows_stream_window() {
     let (io, srv) = mock::new();
 
     let mock = srv.assert_client_handshake().unwrap()
-        .recv_settings()
+        .ignore_settings()
         .recv_frame(
             frames::headers(1)
                 .request("GET", "https://http2.akamai.com/")
@@ -467,7 +467,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
         )
         .send_frame(frames::headers(3).response(200))
         .recv_frame(frames::headers(1).eos())
-        .recv_frame(frames::data(3, b"hello"[..]).eos())
+        .recv_frame(frames::data(3, &b"hello"[..]).eos())
         .close();
 
     let _ = h2.join(srv).wait().unwrap();


### PR DESCRIPTION
I've rewritten the tests `flow_control::stream_close_by_data_frame_releases_capacity()` and `flow_control::stream_close_by_trailers_frame_releases_capacity()` to use the new mock API. This will make modifying these tests a bit easier in order to expect the correct behavior in my [reset on drop branch](https://github.com/carllerche/h2/commits/eliza/reset-on-drop).