### PR TITLE
Update so dependents can compile

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -261,7 +261,7 @@ impl fmt::Debug for Headers {
 
 // ===== impl PushPromise =====
 
-#[allow(dead_code)]
+#[cfg(feature = "unstable")]
 impl PushPromise {
     pub fn new(
         stream_id: StreamId,

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -261,6 +261,7 @@ impl fmt::Debug for Headers {
 
 // ===== impl PushPromise =====
 
+#[allow(dead_code)]
 impl PushPromise {
     pub fn new(
         stream_id: StreamId,

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -6,7 +6,7 @@ use http::{uri, HeaderMap, Method, StatusCode, Uri};
 use http::header::{self, HeaderName, HeaderValue};
 
 use byteorder::{BigEndian, ByteOrder};
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use string::String;
 
 use std::fmt;
@@ -261,25 +261,7 @@ impl fmt::Debug for Headers {
 
 // ===== impl PushPromise =====
 
-#[cfg(feature = "unstable")]
 impl PushPromise {
-    pub fn new(
-        stream_id: StreamId,
-        promised_id: StreamId,
-        pseudo: Pseudo,
-        fields: HeaderMap,
-    ) -> Self {
-        PushPromise {
-            flags: PushPromiseFlag::default(),
-            header_block: HeaderBlock {
-                fields,
-                pseudo,
-            },
-            promised_id,
-            stream_id,
-        }
-    }
-
     /// Loads the push promise frame but doesn't actually do HPACK decoding.
     ///
     /// HPACK decoding is done in the `load_hpack` step.
@@ -337,19 +319,9 @@ impl PushPromise {
         self.flags.is_end_headers()
     }
 
-    pub fn into_parts(self) -> (Pseudo, HeaderMap) {
-        (self.header_block.pseudo, self.header_block.fields)
-    }
-
-    pub fn fields(&self) -> &HeaderMap {
-        &self.header_block.fields
-    }
-
-    pub fn into_fields(self) -> HeaderMap {
-        self.header_block.fields
-    }
-
     pub fn encode(self, encoder: &mut hpack::Encoder, dst: &mut BytesMut) -> Option<Continuation> {
+        use bytes::BufMut;
+
         let head = self.head();
         let pos = dst.len();
 
@@ -370,6 +342,38 @@ impl PushPromise {
 
     fn head(&self) -> Head {
         Head::new(Kind::PushPromise, self.flags.into(), self.stream_id)
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl PushPromise {
+    pub fn new(
+        stream_id: StreamId,
+        promised_id: StreamId,
+        pseudo: Pseudo,
+        fields: HeaderMap,
+    ) -> Self {
+        PushPromise {
+            flags: PushPromiseFlag::default(),
+            header_block: HeaderBlock {
+                fields,
+                pseudo,
+            },
+            promised_id,
+            stream_id,
+        }
+    }
+
+    pub fn into_parts(self) -> (Pseudo, HeaderMap) {
+        (self.header_block.pseudo, self.header_block.fields)
+    }
+
+    pub fn fields(&self) -> &HeaderMap {
+        &self.header_block.fields
+    }
+
+    pub fn into_fields(self) -> HeaderMap {
+        self.header_block.fields
     }
 }
 

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -74,6 +74,7 @@ impl Settings {
         self.max_concurrent_streams
     }
 
+    #[allow(dead_code)]
     pub fn set_max_concurrent_streams(&mut self, max: Option<u32>) {
         self.max_concurrent_streams = max;
     }

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -74,7 +74,7 @@ impl Settings {
         self.max_concurrent_streams
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "unstable")]
     pub fn set_max_concurrent_streams(&mut self, max: Option<u32>) {
         self.max_concurrent_streams = max;
     }


### PR DESCRIPTION
Projects cannot currently depend on the h2 repo due the following compile errors:

```
error: method is never used: `new`
   --> /Users/ver/b/rs/h2/src/frame/headers.rs:265:5
    |
265 | /     pub fn new(
266 | |         stream_id: StreamId,
267 | |         promised_id: StreamId,
268 | |         pseudo: Pseudo,
...   |
279 | |         }
280 | |     }
    | |_____^
    |
note: lint level defined here
   --> /Users/ver/b/rs/h2/src/lib.rs:1:9
    |
1   | #![deny(warnings, missing_debug_implementations)]
    |         ^^^^^^^^
    = note: #[deny(dead_code)] implied by #[deny(warnings)]

error: method is never used: `into_parts`
   --> /Users/ver/b/rs/h2/src/frame/headers.rs:339:5
    |
339 | /     pub fn into_parts(self) -> (Pseudo, HeaderMap) {
340 | |         (self.header_block.pseudo, self.header_block.fields)
341 | |     }
    | |_____^

error: method is never used: `fields`
   --> /Users/ver/b/rs/h2/src/frame/headers.rs:343:5
    |
343 | /     pub fn fields(&self) -> &HeaderMap {
344 | |         &self.header_block.fields
345 | |     }
    | |_____^

error: method is never used: `into_fields`
   --> /Users/ver/b/rs/h2/src/frame/headers.rs:347:5
    |
347 | /     pub fn into_fields(self) -> HeaderMap {
348 | |         self.header_block.fields
349 | |     }
    | |_____^

error: method is never used: `set_max_concurrent_streams`
  --> /Users/ver/b/rs/h2/src/frame/settings.rs:77:5
   |
77 | /     pub fn set_max_concurrent_streams(&mut self, max: Option<u32>) {
78 | |         self.max_concurrent_streams = max;
79 | |     }
   | |_____^

error: aborting due to 5 previous errors

error: Could not compile `h2`.

To learn more, run the command again with --verbose.
```

This change adds two `allow(dead_code)` annotations to prevent these compile errors.

Furthermore, `cargo fmt` has been run.