### PR TITLE
Disallow nightly failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ after_success:
   - cargo tarpaulin --out Xml -- --skip hpack && bash <(curl -s https://codecov.io/bash)
 
 jobs:
-  allow_failures:
-  - rust: nightly
+  # allow_failures:
+  # - rust: nightly
   include:
     - stage: docs
       script: cargo doc --no-deps
@@ -47,7 +47,7 @@ jobs:
       after_success: skip
     - stage: fmt
       rust: nightly
-      install: if ! cargo fmt --help >/dev/null 2>&1 ; then cargo install rustfmt-nightly ; fi
+      install: cargo install --force rustfmt-nightly
       script: cargo fmt -- --write-mode=diff
       after_success: skip
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,7 +187,10 @@ impl Builder {
     #[cfg(feature = "unstable")]
     pub fn initial_stream_id(&mut self, stream_id: u32) -> &mut Self {
         self.stream_id = stream_id.into();
-        assert!(self.stream_id.is_client_initiated(), "stream id must be odd");
+        assert!(
+            self.stream_id.is_client_initiated(),
+            "stream id must be odd"
+        );
         self
     }
 

--- a/src/codec/framed_read.rs
+++ b/src/codec/framed_read.rs
@@ -148,8 +148,8 @@ impl<T> FramedRead<T> {
                 let _ = bytes.split_to(frame::HEADER_LEN);
 
                 // Parse the frame w/o parsing the payload
-                let (mut push, payload) = frame::PushPromise::load(head, bytes)
-                    .map_err(|_| Connection(ProtocolError))?;
+                let (mut push, payload) =
+                    frame::PushPromise::load(head, bytes).map_err(|_| Connection(ProtocolError))?;
 
                 if push.is_end_headers() {
                     // Load the HPACK encoded headers & return the frame
@@ -174,7 +174,6 @@ impl<T> FramedRead<T> {
 
                     return Ok(None);
                 }
-
             },
             Kind::Priority => {
                 if head.stream_id() == 0 {
@@ -313,7 +312,11 @@ impl Continuable {
         }
     }
 
-    fn load_hpack(&mut self, src: BytesMut, decoder: &mut hpack::Decoder) -> Result<(), frame::Error> {
+    fn load_hpack(
+        &mut self,
+        src: BytesMut,
+        decoder: &mut hpack::Decoder,
+    ) -> Result<(), frame::Error> {
         match *self {
             Continuable::Headers(ref mut h) => h.load_hpack(src, decoder),
             Continuable::PushPromise(ref mut p) => p.load_hpack(src, decoder),

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -61,7 +61,7 @@ where
     pub fn new(
         codec: Codec<T, Prioritized<B::Buf>>,
         settings: &frame::Settings,
-        next_stream_id: frame::StreamId
+        next_stream_id: frame::StreamId,
     ) -> Connection<T, P, B> {
         let streams = Streams::new(streams::Config {
             local_init_window_sz: settings

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -154,8 +154,8 @@ where
         }
 
         if !stream.content_length.is_head() {
-            use http::header;
             use super::stream::ContentLength;
+            use http::header;
 
             if let Some(content_length) = frame.fields().get(header::CONTENT_LENGTH) {
                 let content_length = match parse_u64(content_length.as_bytes()) {

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -199,8 +199,8 @@ where
             // There are no more outstanding references to the stream
             self.ref_count == 0 &&
             // The stream is not in any queue
-            !self.is_pending_send && !self.is_pending_send_capacity &&
-            !self.is_pending_accept && !self.is_pending_window_update
+            !self.is_pending_send && !self.is_pending_send_capacity
+            && !self.is_pending_accept && !self.is_pending_window_update
     }
 
     pub fn assign_capacity(&mut self, capacity: WindowSize) {

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -324,8 +324,8 @@ where
         request: Request<()>,
         end_of_stream: bool,
     ) -> Result<StreamRef<B, P>, SendError> {
-        use http::Method;
         use super::stream::ContentLength;
+        use http::Method;
 
         // TODO: There is a hazard with assigning a stream ID before the
         // prioritize layer. If prioritization reorders new streams, this

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -75,9 +75,7 @@ fn request_stream_id_overflows() {
                 .unwrap();
 
             // first request is allowed
-            let req = h2.send_request(request, true)
-                .unwrap()
-                .unwrap();
+            let req = h2.send_request(request, true).unwrap().unwrap();
 
             let request = Request::builder()
                 .method(Method::GET)
@@ -117,17 +115,12 @@ fn request_over_max_concurrent_streams_errors() {
     let (io, srv) = mock::new();
 
 
-    let srv = srv.assert_client_handshake_with_settings(
-            frames::settings()
+    let srv = srv.assert_client_handshake_with_settings(frames::settings()
                 // super tiny server
-                .max_concurrent_streams(1)
-        )
+                .max_concurrent_streams(1))
         .unwrap()
         .recv_settings()
-        .recv_frame(
-            frames::headers(1)
-                .request("POST", "https://example.com/")
-        )
+        .recv_frame(frames::headers(1).request("POST", "https://example.com/"))
         .send_frame(frames::headers(1).response(200))
         .close();
 
@@ -141,15 +134,12 @@ fn request_over_max_concurrent_streams_errors() {
                 .unwrap();
 
             // first request is allowed
-            let req = h2.send_request(request, false)
-                .unwrap()
-                .unwrap();
+            let req = h2.send_request(request, false).unwrap().unwrap();
 
             // drive the connection some so we can receive the server settings
             h2.drive(req)
         })
         .and_then(|(mut h2, _)| {
-
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -380,17 +380,12 @@ fn stream_close_by_data_frame_releases_capacity() {
         h2.unwrap()
     });
 
-    let srv = srv.assert_client_handshake().unwrap()
+    let srv = srv.assert_client_handshake()
+        .unwrap()
         .recv_settings()
-        .recv_frame(
-            frames::headers(1)
-                .request("POST", "https://http2.akamai.com/")
-        )
+        .recv_frame(frames::headers(1).request("POST", "https://http2.akamai.com/"))
         .send_frame(frames::headers(1).response(200))
-        .recv_frame(
-            frames::headers(3)
-                .request("POST", "https://http2.akamai.com/")
-        )
+        .recv_frame(frames::headers(3).request("POST", "https://http2.akamai.com/"))
         .send_frame(frames::headers(3).response(200))
         .recv_frame(frames::data(1, &b""[..]).eos())
         .recv_frame(frames::data(3, &b"hello"[..]).eos())
@@ -536,9 +531,7 @@ fn recv_window_update_on_stream_closed_by_data_frame() {
     let srv = srv.assert_client_handshake()
         .unwrap()
         .recv_settings()
-        .recv_frame(
-            frames::headers(1).request("POST", "https://http2.akamai.com/"),
-        )
+        .recv_frame(frames::headers(1).request("POST", "https://http2.akamai.com/"))
         .send_frame(frames::headers(1).response(200))
         .recv_frame(frames::data(1, "hello").eos())
         .send_frame(frames::window_update(1, 5))
@@ -631,8 +624,8 @@ fn reserved_capacity_assigned_in_multi_window_updates() {
 #[test]
 fn connection_notified_on_released_capacity() {
     use futures::sync::oneshot;
-    use std::thread;
     use std::sync::mpsc;
+    use std::thread;
 
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
@@ -685,15 +678,11 @@ fn connection_notified_on_released_capacity() {
 
         let (mut h2, _) = h2.drive(settings_rx).wait().unwrap();
 
-        let request = Request::get("https://example.com/a")
-            .body(())
-            .unwrap();
+        let request = Request::get("https://example.com/a").body(()).unwrap();
 
         tx.send(h2.send_request(request, true).unwrap()).unwrap();
 
-        let request = Request::get("https://example.com/b")
-            .body(())
-            .unwrap();
+        let request = Request::get("https://example.com/b").body(()).unwrap();
 
         tx.send(h2.send_request(request, true).unwrap()).unwrap();
 

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -16,9 +16,7 @@ fn recv_push_works() {
                 .request("GET", "https://http2.akamai.com/")
                 .eos(),
         )
-        .send_frame(
-            frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"),
-        )
+        .send_frame(frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"))
         .send_frame(frames::headers(1).response(200).eos())
         .send_frame(frames::headers(2).response(200).eos());
 
@@ -55,9 +53,7 @@ fn recv_push_when_push_disabled_is_conn_error() {
                 .request("GET", "https://http2.akamai.com/")
                 .eos(),
         )
-        .send_frame(
-            frames::push_promise(1, 3).request("GET", "https://http2.akamai.com/style.css"),
-        )
+        .send_frame(frames::push_promise(1, 3).request("GET", "https://http2.akamai.com/style.css"))
         .send_frame(frames::headers(1).response(200).eos())
         .recv_frame(frames::go_away(0).protocol_error());
 


### PR DESCRIPTION
Always install rustfmt since nightly may change underneath it, causing linking to break.

Apply rustfmt