### PR TITLE
Only run tests once in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,15 @@ install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
 
 script:
-  # Run tests, uploading results to codecov.
-  - cargo tarpaulin --out Xml
+ # Test examples in README.
+  - cargo build --test && rustdoc --test README.md -L target/debug/deps
 
-  # Test examples in readme
-  - rustdoc --test README.md -L target/debug/deps
+  # Run tests, uploading results to codecov..
+  # hpack tests are _super_ slow in coverage, so skip them here.
+  - cargo tarpaulin --out Xml -- --skip hpack
 
+  # Test _only_ hpack.
+  - cargo test -- hpack
 
 after_success:
   - bash <(curl -Ls https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ rust:
 - beta
 - stable
 
-before_script:
+install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
   # Run tests, uploading results to codecov.
-  - cargo tarpaulin --out Xml -- --skip hpack && bash <(curl -s https://codecov.io/bash)
+  - cargo tarpaulin --out Xml -- --skip hpack
 
   # Run hpack tests outside of codecov. idk why.
   - cargo test -- hpack
@@ -30,6 +30,8 @@ script:
   # Test examples in readme
   - rustdoc --test README.md -L target/debug/deps
 
+after_success:
+  - bash <(curl -Ls https://codecov.io/bash)
 
 jobs:
   # allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
  # Test examples in README.
-  - cargo build --test && rustdoc --test README.md -L target/debug/deps
+  - cargo build --tests && rustdoc --test README.md -L target/debug/deps
 
   # Run tests, uploading results to codecov..
   # hpack tests are _super_ slow in coverage, so skip them here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,19 @@ rust:
 - beta
 - stable
 
+before_script:
+  - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+
 script:
-  # Run tests
-  - cargo test
+  # Run tests, uploading results to codecov.
+  - cargo tarpaulin --out Xml -- --skip hpack && bash <(curl -s https://codecov.io/bash)
+
+  # Run hpack tests outside of codecov. idk why.
+  - cargo test -- hpack
+
   # Test examples in readme
   - rustdoc --test README.md -L target/debug/deps
 
-after_success:
-  - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
-  - cargo tarpaulin --out Xml -- --skip hpack && bash <(curl -s https://codecov.io/bash)
 
 jobs:
   # allow_failures:
@@ -45,6 +49,7 @@ jobs:
           repo: carllerche/h2
           rust: nightly
       after_success: skip
+
     - stage: fmt
       rust: nightly
       install: cargo install --force rustfmt-nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ rust:
 install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
 
+before_script:
+  - cargo clean
+
 script:
  # Test examples in README.
   - cargo build --tests && rustdoc --test README.md -L target/debug/deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,11 @@ install:
 
 script:
   # Run tests, uploading results to codecov.
-  - cargo tarpaulin --out Xml -- --skip hpack
-
-  # Run hpack tests outside of codecov. idk why.
-  - cargo test -- hpack
+  - cargo tarpaulin --out Xml
 
   # Test examples in readme
   - rustdoc --test README.md -L target/debug/deps
+
 
 after_success:
   - bash <(curl -Ls https://codecov.io/bash)


### PR DESCRIPTION
We run codecov after successful test runs. This ~doubles the length of
CI jobs, sicne the codecov run reproduces nearly all tests.

To avoid this, we just run the codecov tests as part of our normal test
script.