### PR TITLE
Run h2spec on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - stage: h2spec
       rust: nightly
       install: |
-        curl -Lhttps://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+        curl -L https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
         tar xf h2spec_linux_amd64.tar.gz
       script: |
         cargo run --example server & ./h2spec -p 5928

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ jobs:
       script:
         - cargo build --example server
         - |
-          exec 3< <(cargo run --example server) &&
-          sed '/listening on Ok(V4(127.0.0.1:5928))$/q' <&3 ; cat <&3 &&
+          exec 3< <(./target/debug/examples/server);
+          sed '/listening on Ok(V4(127.0.0.1:5928))/q' <&3 ; cat <&3 &
           ./h2spec -p 5928
     - stage: docs
       script: cargo doc --no-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ jobs:
       script:
         - cargo build --example server
         - |
-        exec 3< <(cargo run --example server) &&
-        sed '/listening on Ok(V4(127.0.0.1:5928))$/q' <&3 ; cat <&3 &&
-        ./h2spec -p 5928
+          exec 3< <(cargo run --example server) &&
+          sed '/listening on Ok(V4(127.0.0.1:5928))$/q' <&3 ; cat <&3 &&
+          ./h2spec -p 5928
     - stage: docs
       script: cargo doc --no-deps
       install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - stage: h2spec
       rust: nightly
       install: |
-        curl -L https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+        wget -L https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
         tar xf h2spec_linux_amd64.tar.gz
       script: |
         cargo run --example server & ./h2spec -p 5928

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,9 @@ jobs:
   include:
     - stage: h2spec
       rust: nightly
-      install:
-        - curl -Lhttps://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_darwin_amd64.tar.gz
+      install: |
+        curl -Lhttps://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+        tar xf h2spec_linux_amd64.tar.gz
       script: |
         cargo run --example server & ./h2spec -p 5928
     - stage: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,7 @@ jobs:
       install:
         - curl -Lhttps://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_darwin_amd64.tar.gz
       script: |
-        cargo run --example server & &&
-        ./h2spec -p 5928
+        cargo run --example server & ./h2spec -p 5928
     - stage: docs
       script: cargo doc --no-deps
       install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ jobs:
   # allow_failures:
   # - rust: nightly
   include:
+    - stage: h2spec
+      rust: nightly
+      install:
+        - curl -Lhttps://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_darwin_amd64.tar.gz
+      script: |
+        cargo run --example server & &&
+        ./h2spec -p 5928
     - stage: docs
       script: cargo doc --no-deps
       install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,10 @@ jobs:
         tar xf h2spec_linux_amd64.tar.gz
       script:
         - cargo build --example server
-        - cargo run --example server & ./h2spec -p 5928
+        - |
+        exec 3< <(cargo run --example server) &&
+        sed '/listening on Ok(V4(127.0.0.1:5928))$/q' <&3 ; cat <&3 &&
+        ./h2spec -p 5928
     - stage: docs
       script: cargo doc --no-deps
       install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,9 @@ jobs:
       install: |
         wget -L https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
         tar xf h2spec_linux_amd64.tar.gz
-      script: |
-        cargo run --example server & ./h2spec -p 5928
+      script:
+        - cargo build --example server
+        - cargo run --example server & ./h2spec -p 5928
     - stage: docs
       script: cargo doc --no-deps
       install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - stage: h2spec
       rust: nightly
       install: |
-        wget -L https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+        wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
         tar xf h2spec_linux_amd64.tar.gz
       script:
         - cargo build --example server


### PR DESCRIPTION
This currently works, but the build is failing because of issue #110. Waiting on #112 to merge this.

Once I get this merged, I'll also work on collapsing some of the build stages to run in parallel, which should help make CI faster.

Fixes #114.