### PR TITLE
Make CI build flatter (and therefore faster)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
 
   # Run tests, uploading results to codecov..
   # hpack tests are _super_ slow in coverage, so skip them here.
-  - cargo tarpaulin --features unstable --out Xml -- --skip hpack
+  - cargo tarpaulin --features unstable --skip-clean --no-count --out Xml -- --skip hpack
 
   # Test _only_ hpack.
   - cargo test --lib -- hpack

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: false
 cache:
   cargo: true
   apt: true
-  directories:
-    - h2spec
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
     before_script: cargo install --force rustfmt-nightly
     before_deploy: cargo doc --no-deps
   - rust: stable
-    after_install: |
-      wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
-      tar xf h2spec_linux_amd64.tar.gz
+    before_script: |
+        wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+        tar xf h2spec_linux_amd64.tar.gz
 
 install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: false
 cache:
   cargo: true
   apt: true
+  directories:
+    - h2spec
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ addons:
 matrix:
   include:
   - rust: nightly
-    before_script: cargo install --force rustfmt-nightly
     before_deploy: cargo doc --no-deps
   - rust: stable
 
 install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+  - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then cargo install --force rustfmt-nightly; fi
 
 before_script:
   - cargo clean
@@ -42,6 +42,7 @@ script:
   # Test _only_ hpack.
   - cargo test --lib -- hpack
   # run rustfmt on nightly & h2spec on stable
+  # TODO: move installation of h2spec out of the `script` and into `install`?
   - |
     if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
       cargo fmt -- --write-mode=diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,15 @@ addons:
     packages:
     - libssl-dev
 
-rust:
-- nightly
-- stable
+matrix:
+  include:
+  - rust: nightly
+    before_script: cargo install --force rustfmt-nightly
+    before_deploy: cargo doc --no-deps
+  - rust: stable
+    after_install: |
+      wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+      tar xf h2spec_linux_amd64.tar.gz
 
 install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
@@ -38,46 +44,30 @@ script:
 
   # Test _only_ hpack.
   - cargo test --lib -- hpack
+  # run rustfmt on nightly & h2spec on stable
+  - |
+    if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
+      cargo fmt -- --write-mode=diff
+    else
+      cargo build --example server
+      exec 3< <(./target/debug/examples/server);
+      sed '/listening on Ok(V4(127.0.0.1:5928))/q' <&3 ; cat <&3 &
+      ./h2spec -p 5928
+    fi
 
 after_success:
   - bash <(curl -Ls https://codecov.io/bash)
 
-jobs:
-  # allow_failures:
-  # - rust: nightly
-  include:
-    - stage: h2spec
-      rust: nightly
-      install: |
-        wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
-        tar xf h2spec_linux_amd64.tar.gz
-      script:
-        - cargo build --example server
-        - |
-          exec 3< <(./target/debug/examples/server);
-          sed '/listening on Ok(V4(127.0.0.1:5928))/q' <&3 ; cat <&3 &
-          ./h2spec -p 5928
-    - stage: docs
-      script: cargo doc --no-deps
-      install: skip
-      deploy:
-        provider:  pages
-        skip_cleanup: true
-        github_token: $GH_TOKEN
-        target_branch: gh-pages
-        local_dir: target/doc
-        on:
-          branch: master
-          repo: carllerche/h2
-          rust: nightly
-      after_success: skip
-
-    - stage: fmt
-      rust: nightly
-      install: cargo install --force rustfmt-nightly
-      script: cargo fmt -- --write-mode=diff
-      after_success: skip
-
+deploy:
+  provider:  pages
+  skip_cleanup: true
+  github_token: $GH_TOKEN
+  target_branch: gh-pages
+  local_dir: target/doc
+  on:
+    branch: master
+    repo: carllerche/h2
+    rust: nightly
 env:
   global:
   - secure: LkjG3IYPu7GY7zuMdYyLtdvjR4a6elX6or1Du7LTBz4JSlQXYAaj6DxhfZfm4d1kECIlnJJ2T21BqDoJDnld5lLu6VcXQ2ZEo/2f2k77GQ/9w3erwcDtqxK02rPoslFNzSd2SCdafjGKdbcvGW2HVBEu5gYEfOdu1Cdy6Av3+vLPk5To50khBQY90Kk+cmSd7J0+CHw/wSXnVgIVoO4742+aj5pxZQLx3lsi3ZPzIh1VL4QOUlaI98ybrCVNxADQCeXRRDzj0d8NzeKlkm8eXpgpiMVRJWURMa3rU2sHU9wh+YjMyoqGZWv2LlzG5LBqde3RWPQ99ebxVhlly6RgEom8yvZbavcGJ4BA0OjviLYAMb1Wjlu1paLZikEqlvTojhpzz3PVuIBZHl+rUgnUfkuhfmMzTBJTPHPMP0GtqpIAGpyRwbv56DquuEiubl70FZmz52sXGDseoABv9jQ4SNJrDrA+bfIWkPpWwqnKaWIgGPl0n3GKeceQM3RshpaE59awYUDS4ybjtacb2Fr99fx25mTO2W4x5hcDqAvBohxRPXgRB2y0ZmrcJyCV3rfkiGFUK7H8ZBqNQ6GG/GYilgj40q6TgcnXxUxyKkykDiS9VU0QAjAwz0pkCNipJ+ImS1j0LHEOcKMKZ7OsGOuSqBmF24ewBs+XzXY7dTnM/Xc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,19 +41,12 @@ script:
 
   # Test _only_ hpack.
   - cargo test --lib -- hpack
-  # run rustfmt on nightly & h2spec on stable
-  # TODO: move installation of h2spec out of the `script` and into `install`?
-  - |
-    if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
-      cargo fmt -- --write-mode=diff
-    else
-      wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
-      tar xf h2spec_linux_amd64.tar.gz
-      cargo build --example server
-      exec 3< <(./target/debug/examples/server);
-      sed '/listening on Ok(V4(127.0.0.1:5928))/q' <&3 ; cat <&3 &
-      ./h2spec -p 5928
-    fi
+
+  # Run rustfmt on nightly
+  - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then cargo fmt -- --write-mode=diff; fi
+
+  # Run h2spec on stable
+  - if [ "${TRAVIS_RUST_VERSION}" = "stable" ]; then ./ci/h2spec.sh; fi
 
 after_success:
   - bash <(curl -Ls https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
     before_script: cargo install --force rustfmt-nightly
     before_deploy: cargo doc --no-deps
   - rust: stable
-    before_script: |
-        wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
-        tar xf h2spec_linux_amd64.tar.gz
 
 install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
@@ -49,6 +46,8 @@ script:
     if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
       cargo fmt -- --write-mode=diff
     else
+      wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz &&
+      tar xf h2spec_linux_amd64.tar.gz
       cargo build --example server
       exec 3< <(./target/debug/examples/server);
       sed '/listening on Ok(V4(127.0.0.1:5928))/q' <&3 ; cat <&3 &

--- a/ci/h2spec.sh
+++ b/ci/h2spec.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+LOGFILE="h2server.log"
+
+if ! [ -e "h2spec" ] ; then
+    # if we don't already have a h2spec executable, wget it from github
+    wget https://github.com/summerwind/h2spec/releases/download/v2.1.0/h2spec_linux_amd64.tar.gz
+    tar xf h2spec_linux_amd64.tar.gz
+fi
+
+cargo build --example server
+exec 3< <(./target/debug/examples/server);
+SERVER_PID=$!
+
+# wait 'til the server is listening before running h2spec, and pipe server's
+# stdout to a log file.
+sed '/listening on Ok(V4(127.0.0.1:5928))/q' <&3 ; cat <&3 > "${LOGFILE}" &
+
+# run h2spec against the server, printing the server log if h2spec failed
+./h2spec -p 5928
+H2SPEC_STATUS=$?
+if [ "${H2SPEC_STATUS}" -eq 0 ]; then
+    echo "h2spec passed!"
+else
+    echo "h2spec failed! server logs:"
+    cat "${LOGFILE}"
+fi
+kill "${SERVER_PID}"
+exit "${H2SPEC_STATUS}"


### PR DESCRIPTION
Removed build stages from travis configuration. `rustfmt` and doc publishing run are run on the nightly build while `h2spec` runs on the stable build (as suggested by @carllerche). This also adds the changes to make coverage faster added in #118.

Closes #118.