### PR TITLE
Set codecov threshold to 5%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,10 @@ codecov:
     require_ci_to_pass: true
 
 coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
   ignore:
     - fixtures/.*
     - examples/.*
@@ -13,7 +17,7 @@ coverage:
     slack:
       default:
         url: "https://hooks.slack.com/services/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"
-        threshold: 1%
+        threshold: 5%
         only_pulls: false
         branches: null
         flags: null


### PR DESCRIPTION
This PR sets the threshold by which code coverage can drop before Codedov marks the commit as failing or notifies Slack to 5%, as requested by @seanmonstar.