### PR TITLE
when receiving a GOAWAY, allow earlier streams to still process

### DIFF
--- a/src/frame/go_away.rs
+++ b/src/frame/go_away.rs
@@ -16,7 +16,6 @@ impl GoAway {
         }
     }
 
-    #[cfg(feature = "unstable")]
     pub fn last_stream_id(&self) -> StreamId {
         self.last_stream_id
     }
@@ -27,9 +26,7 @@ impl GoAway {
 
     pub fn load(payload: &[u8]) -> Result<GoAway, Error> {
         if payload.len() < 8 {
-            // Invalid payload len
-            // TODO: Handle error
-            unimplemented!();
+            return Err(Error::BadFrameSize);
         }
 
         let (last_stream_id, _) = StreamId::parse(&payload[..4]);

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -222,7 +222,6 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
 impl<B, P> Store<B, P>
 where
     P: Peer,
@@ -231,6 +230,7 @@ where
         self.ids.len()
     }
 
+    #[cfg(feature = "unstable")]
     pub fn num_wired_streams(&self) -> usize {
         self.slab.len()
     }


### PR DESCRIPTION
This is a first step to better GOAWAY support (cc #83). This patch will close all streams greater than the last stream ID in the GOAWAY frame, but allow streams less than to still finish.