### PR TITLE
remove unused pieces from PingPong

### DIFF
--- a/src/frame/ping.rs
+++ b/src/frame/ping.rs
@@ -13,10 +13,10 @@ pub struct Ping {
 
 impl Ping {
     #[cfg(feature = "unstable")]
-    pub fn new() -> Ping {
+    pub fn new(payload: Payload) -> Ping {
         Ping {
             ack: false,
-            payload: Payload::default(),
+            payload,
         }
     }
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -30,7 +30,7 @@ where
     codec: Codec<T, Prioritized<B::Buf>>,
 
     /// Ping/pong handler
-    ping_pong: PingPong<Prioritized<B::Buf>>,
+    ping_pong: PingPong,
 
     /// Connection settings
     settings: Settings,

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -15,7 +15,7 @@ fn recv_single_ping() {
     let mock = mock.assert_client_handshake()
         .unwrap()
         .and_then(|(_, mut mock)| {
-            let frame = frame::Ping::new();
+            let frame = frame::Ping::new(Default::default());
             mock.send(frame.into()).unwrap();
 
             mock.into_future().unwrap()
@@ -33,4 +33,74 @@ fn recv_single_ping() {
         });
 
     let _ = h2.join(mock).wait().unwrap();
+}
+
+#[test]
+fn recv_multiple_pings() {
+    let _ = ::env_logger::init();
+    let (io, client) = mock::new();
+
+    let client = client.assert_server_handshake()
+        .expect("client handshake")
+        .recv_settings()
+        .send_frame(frames::ping([1; 8]))
+        .send_frame(frames::ping([2; 8]))
+        .recv_frame(frames::ping([1; 8]).pong())
+        .recv_frame(frames::ping([2; 8]).pong())
+        .close();
+
+    let srv = Server::handshake(io)
+        .expect("handshake")
+        .and_then(|srv| {
+            // future of first request, which never comes
+            srv.into_future().unwrap()
+        });
+
+    srv.join(client).wait().expect("wait");
+}
+
+#[test]
+fn pong_has_highest_priority() {
+    let _ = ::env_logger::init();
+    let (io, client) = mock::new();
+
+    let data = Bytes::from(vec![0; 16_384]);
+
+    let client = client.assert_server_handshake()
+        .expect("client handshake")
+        .recv_settings()
+        .send_frame(
+            frames::headers(1)
+                .request("POST", "https://http2.akamai.com/")
+        )
+        .send_frame(frames::data(1, data.clone()).eos())
+        .send_frame(frames::ping([1; 8]))
+        .recv_frame(frames::ping([1; 8]).pong())
+        .recv_frame(frames::headers(1).response(200).eos())
+        .close();
+
+    let srv = Server::handshake(io)
+        .expect("handshake")
+        .and_then(|srv| {
+            // future of first request
+            srv.into_future().unwrap()
+        }).and_then(move |(reqstream, srv)| {
+            let (req, mut stream) = reqstream.expect("request");
+            assert_eq!(req.method(), "POST");
+            let body = req.into_parts().1;
+
+            body.concat2()
+                .expect("body")
+                .and_then(move |body| {
+                    assert_eq!(body.len(), data.len());
+                    let res = Response::builder()
+                        .status(200)
+                        .body(())
+                        .unwrap();
+                    stream.send_response(res, true).expect("response");
+                    srv.into_future().unwrap()
+                })
+        });
+
+    srv.join(client).wait().expect("wait");
 }

--- a/tests/support/frames.rs
+++ b/tests/support/frames.rs
@@ -68,6 +68,10 @@ pub fn settings() -> Mock<frame::Settings> {
     Mock(frame::Settings::default())
 }
 
+pub fn ping(payload: [u8; 8]) -> Mock<frame::Ping> {
+    Mock(frame::Ping::new(payload))
+}
+
 // === Generic helpers of all frame types
 
 pub struct Mock<T>(T);
@@ -260,6 +264,21 @@ impl From<Mock<frame::Settings>> for frame::Settings {
 impl From<Mock<frame::Settings>> for SendFrame {
     fn from(src: Mock<frame::Settings>) -> Self {
         Frame::Settings(src.0)
+    }
+}
+
+// ==== Ping helpers
+
+impl Mock<frame::Ping> {
+    pub fn pong(self) -> Self {
+        let payload = self.0.into_payload();
+        Mock(frame::Ping::pong(payload))
+    }
+}
+
+impl From<Mock<frame::Ping>> for SendFrame {
+    fn from(src: Mock<frame::Ping>) -> Self {
+        Frame::Ping(src.0)
     }
 }
 


### PR DESCRIPTION
Adds some extra tests as well, to be sure.

We probably want to expose an API for a user to be able to send pings, to allow them to record latency and otherwise know that the remote is still there, but until we do, these fields are just bloat.