### PR TITLE
Remove most instances of unimplemented!

### DIFF
--- a/src/hpack/huffman/mod.rs
+++ b/src/hpack/huffman/mod.rs
@@ -93,7 +93,7 @@ impl Decoder {
 
         if flags & ERROR == ERROR {
             // Data followed the EOS marker
-            unimplemented!();
+            return Err(DecoderError::InvalidHuffmanCode);
         }
 
         let mut ret = None;

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -107,8 +107,7 @@ where
         let sz = frame.payload().remaining();
 
         if sz > MAX_WINDOW_SIZE as usize {
-            // TODO: handle overflow
-            unimplemented!();
+            return Err(UserError::PayloadTooBig);
         }
 
         let sz = sz as WindowSize;

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -263,9 +263,9 @@ where
     ) -> Result<(), RecvError> {
         let sz = frame.payload().len();
 
-        if sz > MAX_WINDOW_SIZE as usize {
-            unimplemented!();
-        }
+        // This should have been enforced at the codec::FramedRead layer, so
+        // this is just a sanity check.
+        assert!(sz <= MAX_WINDOW_SIZE as usize);
 
         let sz = sz as WindowSize;
 
@@ -611,7 +611,7 @@ where
                 // TODO: This is a user error. `poll_trailers` was called before
                 // the entire set of data frames have been consumed. What should
                 // we do?
-                unimplemented!();
+                panic!("poll_trailers called before data has been consumed");
             },
             None => self.schedule_recv(stream),
         }
@@ -654,7 +654,7 @@ where
         // frame or the user violated the contract.
         match stream.pending_recv.pop_front(&mut self.buffer) {
             Some(Event::Headers(response)) => Ok(response.into()),
-            Some(_) => unimplemented!(),
+            Some(_) => panic!("poll_response called after response returned"),
             None => {
                 stream.state.ensure_recv_open()?;
 

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -152,9 +152,10 @@ where
             if let Some(content_length) = frame.fields().get(header::CONTENT_LENGTH) {
                 let content_length = match parse_u64(content_length.as_bytes()) {
                     Ok(v) => v,
-                    Err(_) => {
-                        unimplemented!();
-                    },
+                    Err(_) => return Err(RecvError::Stream {
+                        id: stream.id,
+                        reason: Reason::ProtocolError,
+                    }),
                 };
 
                 stream.content_length = ContentLength::Remaining(content_length);

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -149,7 +149,7 @@ impl Handle {
                 let (settings, me) = res.unwrap();
 
                 me.into_future()
-                    .map_err(|_| unimplemented!())
+                    .map_err(|_| unreachable!("all previous futures unwrapped"))
                     .map(|(frame, me)| {
                         let f = assert_settings!(frame.unwrap());
 


### PR DESCRIPTION
Trying to increase robustness and reduce panics, I've swept through the `unimplemented!`s, and converted most of them into something more appropriate. The ones I left required more thought, and are sufficiently rare that I didn't want to block these.