### PR TITLE
reset streams when receiving malformed pseudo headers

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -211,6 +211,11 @@ impl Headers {
         (self.header_block.pseudo, self.header_block.fields)
     }
 
+    #[cfg(feature = "unstable")]
+    pub fn pseudo_mut(&mut self) -> &mut Pseudo {
+        &mut self.header_block.pseudo
+    }
+
     pub fn fields(&self) -> &HeaderMap {
         &self.header_block.fields
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -513,15 +513,15 @@ impl proto::Peer for Peer {
         let mut parts = uri::Parts::default();
 
         if let Some(scheme) = pseudo.scheme {
-            // TODO: Don't unwrap
-            parts.scheme = Some(uri::Scheme::from_shared(scheme.into_inner()).unwrap());
+            parts.scheme = Some(uri::Scheme::from_shared(scheme.into_inner())
+                .or_else(|_| malformed!())?);
         } else {
             malformed!();
         }
 
         if let Some(authority) = pseudo.authority {
-            // TODO: Don't unwrap
-            parts.authority = Some(uri::Authority::from_shared(authority.into_inner()).unwrap());
+            parts.authority = Some(uri::Authority::from_shared(authority.into_inner())
+                .or_else(|_| malformed!())?);
         }
 
         if let Some(path) = pseudo.path {
@@ -530,8 +530,8 @@ impl proto::Peer for Peer {
                 malformed!();
             }
 
-            // TODO: Don't unwrap
-            parts.path_and_query = Some(uri::PathAndQuery::from_shared(path.into_inner()).unwrap());
+            parts.path_and_query = Some(uri::PathAndQuery::from_shared(path.into_inner())
+                .or_else(|_| malformed!())?);
         }
 
         b.uri(parts);

--- a/tests/support/frames.rs
+++ b/tests/support/frames.rs
@@ -136,6 +136,12 @@ impl Mock<frame::Headers> {
     }
 }
 
+impl From<Mock<frame::Headers>> for frame::Headers {
+    fn from(src: Mock<frame::Headers>) -> Self {
+        src.0
+    }
+}
+
 impl From<Mock<frame::Headers>> for SendFrame {
     fn from(src: Mock<frame::Headers>) -> Self {
         Frame::Headers(src.0)
@@ -234,6 +240,11 @@ impl From<Mock<frame::GoAway>> for SendFrame {
 // ==== Reset helpers
 
 impl Mock<frame::Reset> {
+    pub fn protocol_error(self) -> Self {
+        let id = self.0.stream_id();
+        Mock(frame::Reset::new(id, frame::Reason::ProtocolError))
+    }
+
     pub fn flow_control(self) -> Self {
         let id = self.0.stream_id();
         Mock(frame::Reset::new(id, frame::Reason::FlowControlError))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -12,6 +12,7 @@ pub extern crate futures;
 pub extern crate h2;
 pub extern crate http;
 pub extern crate mock_io;
+pub extern crate string;
 pub extern crate tokio_io;
 
 // Kind of annoying, but we can't use macros from crates that aren't specified

--- a/tests/support/util.rs
+++ b/tests/support/util.rs
@@ -1,7 +1,12 @@
 use h2::client;
 
+use super::string::{String, TryFrom};
 use bytes::Bytes;
 use futures::{Async, Future, Poll};
+
+pub fn byte_str(s: &str) -> String<Bytes> {
+    String::try_from(Bytes::from(s)).unwrap()
+}
 
 pub fn wait_for_capacity(stream: client::Stream<Bytes>, target: usize) -> WaitForCapacity {
     WaitForCapacity {


### PR DESCRIPTION
Closes #120 

(also includes some rustfmt changes I've forgotten in the past few PRs...)