### PR TITLE
Depend on http:0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.1"
 tokio-io = "0.1.3"
 tokio-timer = "0.1"
 bytes = "0.4"
-http = { git = "https://github.com/carllerche/http" }
+http = { git = "https://github.com/hyperium/http" }
 byteorder = "1.0"
 log = "0.3.8"
 fnv = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.1"
 tokio-io = "0.1.3"
 tokio-timer = "0.1"
 bytes = "0.4"
-http = { git = "https://github.com/hyperium/http" }
+http = "0.1"
 byteorder = "1.0"
 log = "0.3.8"
 fnv = "1.0.5"


### PR DESCRIPTION
Other users of the http crate may depend on crates.io or hyperium/http... This ambiguity leads to compile errors. Depending on crates.io allows dependents to override the repo dependency more easily.