### PR TITLE
Fail CI builds if tests could not be compiled (workaround for #143)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,11 @@ script:
   # Check with unstable flag
   - cargo check --features unstable
 
-  # Run tests, uploading results to codecov..
+  # Build the test executables in a separate step, since Tarpaulin
+  # will not fail on test compile errors.
+  - cargo build --tests --features unstable
+
+  # Run tests, uploading results to codecov.
   # hpack tests are _super_ slow in coverage, so skip them here.
   - cargo tarpaulin --features unstable --skip-clean --no-count --out Xml -- --skip hpack
 


### PR DESCRIPTION
Tarpaulin – the coverage tool we're using on CI – exits with 0 if a compile error occurred when compiling tests. Since we are currently only building and running tests with Tarpaulin, this means that builds where the tests couldn't be compiled successfully are erroneously being marked as "successful" – see #143 for details.

Closes #143.