### PR TITLE
Use remote window size for send flow control

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -51,11 +51,11 @@ where
     pub fn new(config: &Config) -> Prioritize<B, P> {
         let mut flow = FlowControl::new();
 
-        flow.inc_window(config.local_init_window_sz)
+        flow.inc_window(config.remote_init_window_sz)
             .ok()
             .expect("invalid initial window size");
 
-        flow.assign_capacity(config.local_init_window_sz);
+        flow.assign_capacity(config.remote_init_window_sz);
 
         trace!("Prioritize::new; flow={:?}", flow);
 


### PR DESCRIPTION
The initial window size of both the send and recv flow controllers are
configured from the same setting. The send flow controller should be
configured from the remote's initial window size.

I'm unsure of how to test this.