### PR TITLE
add set_target_window_size methods to Server and Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -243,6 +243,21 @@ impl Default for Builder {
 
 // ===== impl Connection =====
 
+
+impl<T, B> Connection<T, B>
+where
+    T: AsyncRead + AsyncWrite,
+    B: IntoBuf,
+{
+    /// Sets the target window size for the whole connection.
+    ///
+    /// Default in HTTP2 is 65_535.
+    pub fn set_target_window_size(&mut self, size: u32) {
+        assert!(size <= proto::MAX_WINDOW_SIZE);
+        self.inner.set_target_window_size(size);
+    }
+}
+
 impl<T, B> Future for Connection<T, B>
 where
     T: AsyncRead + AsyncWrite,

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -91,6 +91,10 @@ where
         }
     }
 
+    pub fn set_target_window_size(&mut self, size: WindowSize) {
+        self.streams.set_target_connection_window_size(size);
+    }
+
     /// Returns `Ready` when the connection is ready to receive a frame.
     ///
     /// Returns `RecvError` as this may raise errors that are caused by delayed

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -187,7 +187,7 @@ where
             stream.requested_send_capacity = capacity;
 
             // Currently available capacity assigned to the stream
-            let available = stream.send_flow.available();
+            let available = stream.send_flow.available().as_size();
 
             // If the stream has more assigned capacity than requested, reclaim
             // some for the connection
@@ -275,9 +275,9 @@ where
         // The amount of additional capacity that the stream requests.
         // Don't assign more than the window has available!
         let additional = cmp::min(
-            total_requested - stream.send_flow.available(),
+            total_requested - stream.send_flow.available().as_size(),
             // Can't assign more than what is available
-            stream.send_flow.window_size() - stream.send_flow.available(),
+            stream.send_flow.window_size() - stream.send_flow.available().as_size(),
         );
 
         trace!(
@@ -304,7 +304,7 @@ where
         );
 
         // The amount of currently available capacity on the connection
-        let conn_available = self.flow.available();
+        let conn_available = self.flow.available().as_size();
 
         // First check if capacity is immediately available
         if conn_available > 0 {
@@ -550,7 +550,7 @@ where
                             let len = cmp::min(sz, max_len);
 
                             // Only send up to the stream's window capacity
-                            let len = cmp::min(len, stream_capacity as usize) as WindowSize;
+                            let len = cmp::min(len, stream_capacity.as_size() as usize) as WindowSize;
 
                             // There *must* be be enough connection level
                             // capacity at this point.

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -80,6 +80,15 @@ where
         }
     }
 
+    pub fn set_target_connection_window_size(&mut self, size: WindowSize) {
+        let mut me = self.inner.lock().unwrap();
+        let me = &mut *me;
+
+        me.actions
+            .recv
+            .set_target_connection_window(size, &mut me.actions.task)
+    }
+
     /// Process inbound headers
     pub fn recv_headers(&mut self, frame: frame::Headers) -> Result<(), RecvError> {
         let id = frame.stream_id();

--- a/src/server.rs
+++ b/src/server.rs
@@ -121,6 +121,14 @@ where
         }
     }
 
+    /// Sets the target window size for the whole connection.
+    ///
+    /// Default in HTTP2 is 65_535.
+    pub fn set_target_window_size(&mut self, size: u32) {
+        assert!(size <= proto::MAX_WINDOW_SIZE);
+        self.connection.set_target_window_size(size);
+    }
+
     /// Returns `Ready` when the underlying connection has closed.
     pub fn poll_close(&mut self) -> Poll<(), ::Error> {
         self.connection.poll().map_err(Into::into)

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -538,7 +538,7 @@ impl Future for Idle {
         match self.handle.as_mut().unwrap().poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
             res => {
-                panic!("Received unexpected frame on handle; frame={:?}", res);
+                panic!("Idle received unexpected frame on handle; frame={:?}", res);
             },
         }
     }


### PR DESCRIPTION
We already track how much of the window is "reserved" by body streams, with connection flows having the default initial size of 65,535. As streams reserve some and release some, the connection window gets reset back up to that number (because we always subtract and then add the same amount to it).

This PR adds a new method to allow stating that the target window size is no longer the default, but something else. If the difference from the default is large enough, a WINDOW_UPDATE is sent out (because of our queuing of updates). Besides that, as streams use the connection window, and then release it back, we'll continue to send updates to the remote to get the window back to the target size (again, based on queuing window updates till a threshold is reached).

Closes #101 
