### PR TITLE
Split response future from `client::Stream`

### DIFF
--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -75,9 +75,9 @@ pub fn main() {
                     .body(())
                     .unwrap();
 
-                let stream = client.send_request(request, true).unwrap();
+                let (response, _) = client.send_request(request, true).unwrap();
 
-                let stream = stream.and_then(|response| {
+                let stream = response.and_then(|response| {
                     let (_, body) = response.into_parts();
 
                     body.for_each(|chunk| {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -70,7 +70,7 @@ pub fn main() {
             let mut trailers = HeaderMap::new();
             trailers.insert("zomg", "hello".parse().unwrap());
 
-            let mut stream = client.send_request(request, false).unwrap();
+            let (response, mut stream) = client.send_request(request, false).unwrap();
 
             // send trailers
             stream.send_trailers(trailers).unwrap();
@@ -78,7 +78,7 @@ pub fn main() {
             // Spawn a task to run the conn...
             handle.spawn(h2.map_err(|e| println!("GOT ERR={:?}", e)));
 
-            stream
+            response
                 .and_then(|response| {
                     println!("GOT RESPONSE: {:?}", response);
 

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -29,7 +29,7 @@ fn recv_push_works() {
         let req = client
             .send_request(request, true)
             .unwrap()
-            .unwrap()
+            .0.unwrap()
             .and_then(|resp| {
                 assert_eq!(resp.status(), StatusCode::OK);
                 Ok(())
@@ -68,7 +68,8 @@ fn recv_push_when_push_disabled_is_conn_error() {
                 .uri("https://http2.akamai.com/")
                 .body(())
                 .unwrap();
-            let req = client.send_request(request, true).unwrap().then(|res| {
+
+            let req = client.send_request(request, true).unwrap().0.then(|res| {
                 let err = res.unwrap_err();
                 assert_eq!(
                     err.to_string(),

--- a/tests/trailers.rs
+++ b/tests/trailers.rs
@@ -32,9 +32,9 @@ fn recv_trailers_only() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = client.send_request(request, true).unwrap();
+    let (response, _) = client.send_request(request, true).unwrap();
 
-    let response = h2.run(poll_fn(|| stream.poll_response())).unwrap();
+    let response = h2.run(response).unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     let (_, mut body) = response.into_parts();
@@ -80,14 +80,14 @@ fn send_trailers_immediately() {
         .unwrap();
 
     info!("sending request");
-    let mut stream = client.send_request(request, false).unwrap();
+    let (response, mut stream) = client.send_request(request, false).unwrap();
 
     let mut trailers = HeaderMap::new();
     trailers.insert("zomg", "hello".parse().unwrap());
 
     stream.send_trailers(trailers).unwrap();
 
-    let response = h2.run(poll_fn(|| stream.poll_response())).unwrap();
+    let response = h2.run(response).unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     let (_, mut body) = response.into_parts();


### PR DESCRIPTION
This allows having separate tasks to manage sending bodies and receiving the response without having to wrap `client::Stream` in an `Arc<Mutex<..>>`.