### PR TITLE
API cleanup

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -6,7 +6,7 @@ extern crate io_dump;
 extern crate tokio_core;
 
 use h2::client::{Client};
-use h2::Body;
+use h2::RecvStream;
 
 use futures::*;
 use http::*;
@@ -15,7 +15,7 @@ use tokio_core::net::TcpStream;
 use tokio_core::reactor;
 
 struct Process {
-    body: Body,
+    body: RecvStream,
     trailers: bool,
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,8 @@ extern crate http;
 extern crate io_dump;
 extern crate tokio_core;
 
-use h2::client::{Body, Client};
+use h2::client::{Client};
+use h2::Body;
 
 use futures::*;
 use http::*;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,4 +1,3 @@
-extern crate bytes;
 extern crate env_logger;
 extern crate futures;
 extern crate h2;
@@ -8,7 +7,6 @@ extern crate tokio_core;
 
 use h2::client::{Body, Client};
 
-use bytes::*;
 use futures::*;
 use http::*;
 
@@ -16,7 +14,7 @@ use tokio_core::net::TcpStream;
 use tokio_core::reactor;
 
 struct Process {
-    body: Body<Bytes>,
+    body: Body,
     trailers: bool,
 }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -31,18 +31,21 @@ pub fn main() {
             .and_then(|conn| {
                 println!("H2 connection bound");
 
-                conn.for_each(|(request, mut stream)| {
+                conn.for_each(|(request, mut respond)| {
                     println!("GOT request: {:?}", request);
-
 
                     let response = Response::builder().status(StatusCode::OK).body(()).unwrap();
 
-                    if let Err(e) = stream.send_response(response, false) {
-                        println!(" error responding; err={:?}", e);
-                    }
+                    let mut send = match respond.send_response(response, false) {
+                        Ok(send) => send,
+                        Err(e) => {
+                            println!(" error respond; err={:?}", e);
+                            return Ok(());
+                        }
+                    };
 
                     println!(">>>> sending data");
-                    if let Err(e) = stream.send_data(Bytes::from_static(b"hello world"), true) {
+                    if let Err(e) = send.send_data(Bytes::from_static(b"hello world"), true) {
                         println!("  -> err={:?}", e);
                     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -395,7 +395,8 @@ impl<B: IntoBuf> Stream<B> {
         self.inner.send_trailers(trailers).map_err(Into::into)
     }
 
-    pub fn send_reset(mut self, reason: Reason) {
+    /// Reset the stream
+    pub fn send_reset(&mut self, reason: Reason) {
         self.inner.send_reset(reason)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,18 @@
 use codec::{Codec, RecvError};
 use frame::{Headers, Pseudo, Reason, Settings, StreamId};
-use proto::{self, WindowSize};
+use proto;
 
 use bytes::{Bytes, IntoBuf};
 use futures::{Async, Future, MapErr, Poll};
-use http::{HeaderMap, Request, Response};
+use http::{Request, Response};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::io::WriteAll;
 
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
+
+pub use share::*;
 
 /// In progress H2 connection binding
 pub struct Handshake<T: AsyncRead + AsyncWrite, B: IntoBuf = Bytes> {
@@ -31,20 +33,6 @@ pub struct Connection<T, B: IntoBuf> {
 
 #[derive(Debug)]
 pub struct ResponseFuture<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf>,
-}
-
-#[derive(Debug)]
-pub struct Stream<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf>,
-}
-
-pub struct Body<B: IntoBuf> {
-    inner: ReleaseCapacity<B>,
-}
-
-#[derive(Debug)]
-pub struct ReleaseCapacity<B: IntoBuf> {
     inner: proto::StreamRef<B::Buf>,
 }
 
@@ -131,9 +119,7 @@ where
                     inner: stream.clone(),
                 };
 
-                let stream = Stream {
-                    inner: stream,
-                };
+                let stream = Stream::new(stream);
 
                 (response, stream)
             })
@@ -354,107 +340,9 @@ impl<B: IntoBuf> Future for ResponseFuture<B> {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let (parts, _) = try_ready!(self.inner.poll_response()).into_parts();
-
-        let body = Body {
-            inner: ReleaseCapacity { inner: self.inner.clone() },
-        };
+        let body = Body::new(ReleaseCapacity::new(self.inner.clone()));
 
         Ok(Response::from_parts(parts, body).into())
-    }
-}
-
-// ===== impl Stream =====
-
-impl<B: IntoBuf> Stream<B> {
-    /// Request capacity to send data
-    pub fn reserve_capacity(&mut self, capacity: usize) {
-        // TODO: Check for overflow
-        self.inner.reserve_capacity(capacity as WindowSize)
-    }
-
-    /// Returns the stream's current send capacity.
-    pub fn capacity(&self) -> usize {
-        self.inner.capacity() as usize
-    }
-
-    /// Request to be notified when the stream's capacity increases
-    pub fn poll_capacity(&mut self) -> Poll<Option<usize>, ::Error> {
-        let res = try_ready!(self.inner.poll_capacity());
-        Ok(Async::Ready(res.map(|v| v as usize)))
-    }
-
-    /// Send data
-    pub fn send_data(&mut self, data: B, end_of_stream: bool) -> Result<(), ::Error> {
-        self.inner
-            .send_data(data.into_buf(), end_of_stream)
-            .map_err(Into::into)
-    }
-
-    /// Send trailers
-    pub fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), ::Error> {
-        self.inner.send_trailers(trailers).map_err(Into::into)
-    }
-
-    /// Reset the stream
-    pub fn send_reset(&mut self, reason: Reason) {
-        self.inner.send_reset(reason)
-    }
-}
-
-// ===== impl Body =====
-
-impl<B: IntoBuf> Body<B> {
-    pub fn is_empty(&self) -> bool {
-        // If the recv side is closed and the receive queue is empty, the body is empty.
-        self.inner.inner.body_is_empty()
-    }
-
-    pub fn release_capacity(&mut self) -> &mut ReleaseCapacity<B> {
-        &mut self.inner
-    }
-
-    /// Poll trailers
-    ///
-    /// This function **must** not be called until `Body::poll` returns `None`.
-    pub fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, ::Error> {
-        self.inner.inner.poll_trailers().map_err(Into::into)
-    }
-}
-
-impl<B: IntoBuf> ::futures::Stream for Body<B> {
-    type Item = Bytes;
-    type Error = ::Error;
-
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.inner.inner.poll_data().map_err(Into::into)
-    }
-}
-
-impl<B: IntoBuf> fmt::Debug for Body<B>
-where B: fmt::Debug,
-      B::Buf: fmt::Debug,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Body")
-            .field("inner", &self.inner)
-            .finish()
-    }
-}
-
-// ===== impl ReleaseCapacity =====
-
-impl<B: IntoBuf> ReleaseCapacity<B> {
-    pub fn release_capacity(&mut self, sz: usize) -> Result<(), ::Error> {
-        self.inner
-            .release_capacity(sz as proto::WindowSize)
-            .map_err(Into::into)
-    }
-}
-
-impl<B: IntoBuf> Clone for ReleaseCapacity<B> {
-    fn clone(&self) -> Self {
-        let inner = self.inner.clone();
-        ReleaseCapacity { inner }
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,12 +31,12 @@ pub struct Connection<T, B: IntoBuf> {
 
 #[derive(Debug)]
 pub struct ResponseFuture<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf, Peer>,
+    inner: proto::StreamRef<B::Buf>,
 }
 
 #[derive(Debug)]
 pub struct Stream<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf, Peer>,
+    inner: proto::StreamRef<B::Buf>,
 }
 
 pub struct Body<B: IntoBuf> {
@@ -45,7 +45,7 @@ pub struct Body<B: IntoBuf> {
 
 #[derive(Debug)]
 pub struct ReleaseCapacity<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf, Peer>,
+    inner: proto::StreamRef<B::Buf>,
 }
 
 /// Build a Client.
@@ -463,6 +463,11 @@ impl<B: IntoBuf> Clone for ReleaseCapacity<B> {
 impl proto::Peer for Peer {
     type Send = Request<()>;
     type Poll = Response<()>;
+
+
+    fn dyn() -> proto::DynPeer {
+        proto::DynPeer::Client
+    }
 
     fn is_server() -> bool {
         false

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+use {Stream, Body, ReleaseCapacity};
 use codec::{Codec, RecvError};
 use frame::{Headers, Pseudo, Reason, Settings, StreamId};
 use proto;
@@ -11,8 +12,6 @@ use tokio_io::io::WriteAll;
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
-
-pub use share::*;
 
 /// In progress H2 connection binding
 pub struct Handshake<T: AsyncRead + AsyncWrite, B: IntoBuf = Bytes> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod server;
 mod share;
 
 pub use error::{Error, Reason};
-pub use share::{Stream, Body, ReleaseCapacity};
+pub use share::{SendStream, RecvStream, ReleaseCapacity};
 
 #[cfg(feature = "unstable")]
 pub use codec::{Codec, RecvError, SendError, UserError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,26 +7,20 @@ extern crate futures;
 extern crate tokio_io;
 
 // HTTP types
-
 extern crate http;
 
 // Buffer utilities
-
 extern crate bytes;
 
 // Hash function used for HPACK encoding and tracking stream states.
-
 extern crate fnv;
 
 extern crate byteorder;
-
 extern crate slab;
 
 #[macro_use]
 extern crate log;
-
 extern crate string;
-
 extern crate ordermap;
 
 mod error;
@@ -45,6 +39,7 @@ pub mod server;
 mod share;
 
 pub use error::{Error, Reason};
+pub use share::{Stream, Body, ReleaseCapacity};
 
 #[cfg(feature = "unstable")]
 pub use codec::{Codec, RecvError, SendError, UserError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod frame;
 
 pub mod client;
 pub mod server;
+mod share;
 
 pub use error::{Error, Reason};
 

--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -301,7 +301,7 @@ where
     T: AsyncRead + AsyncWrite,
     B: IntoBuf,
 {
-    pub fn next_incoming(&mut self) -> Option<StreamRef<B::Buf, server::Peer>> {
+    pub fn next_incoming(&mut self) -> Option<StreamRef<B::Buf>> {
         self.streams.next_incoming()
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -8,7 +8,7 @@ mod streams;
 pub(crate) use self::connection::Connection;
 pub(crate) use self::error::Error;
 pub(crate) use self::peer::{Peer, Dyn as DynPeer};
-pub(crate) use self::streams::{Key as StreamKey, StreamRef, Streams};
+pub(crate) use self::streams::{Key as StreamKey, StreamRef, OpaqueStreamRef, Streams};
 
 use codec::Codec;
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -7,7 +7,7 @@ mod streams;
 
 pub(crate) use self::connection::Connection;
 pub(crate) use self::error::Error;
-pub(crate) use self::peer::Peer;
+pub(crate) use self::peer::{Peer, Dyn as DynPeer};
 pub(crate) use self::streams::{Key as StreamKey, StreamRef, Streams};
 
 use codec::Codec;

--- a/src/proto/peer.rs
+++ b/src/proto/peer.rs
@@ -1,5 +1,8 @@
 use codec::RecvError;
+use error::Reason;
 use frame::{Headers, StreamId};
+
+use http::{Request, Response};
 
 use std::fmt;
 
@@ -11,6 +14,8 @@ pub trait Peer {
     /// Message type polled from the transport
     type Poll: fmt::Debug;
 
+    fn dyn() -> Dyn;
+
     fn is_server() -> bool;
 
     fn convert_send_message(id: StreamId, headers: Self::Send, end_of_stream: bool) -> Headers;
@@ -20,5 +25,59 @@ pub trait Peer {
     fn is_local_init(id: StreamId) -> bool {
         assert!(!id.is_zero());
         Self::is_server() == id.is_server_initiated()
+    }
+}
+
+/// A dynamic representation of `Peer`.
+///
+/// This is used internally to avoid incurring a generic on all internal types.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Dyn {
+    Client,
+    Server,
+}
+
+#[derive(Debug)]
+pub enum PollMessage {
+    Client(Response<()>),
+    Server(Request<()>),
+}
+
+// ===== impl Dyn =====
+
+impl Dyn {
+    pub fn is_server(&self) -> bool {
+        *self == Dyn::Server
+    }
+
+    pub fn is_local_init(&self, id: StreamId) -> bool {
+        assert!(!id.is_zero());
+        self.is_server() == id.is_server_initiated()
+    }
+
+    pub fn convert_poll_message(&self, headers: Headers) -> Result<PollMessage, RecvError> {
+        if self.is_server() {
+            ::server::Peer::convert_poll_message(headers)
+                .map(PollMessage::Server)
+        } else {
+            ::client::Peer::convert_poll_message(headers)
+                .map(PollMessage::Client)
+        }
+    }
+
+    /// Returns true if the remote peer can initiate a stream with the given ID.
+    pub fn ensure_can_open(&self, id: StreamId) -> Result<(), RecvError> {
+        if !self.is_server() {
+            // Remote is a server and cannot open streams. PushPromise is
+            // registered by reserving, so does not go through this path.
+            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+        }
+
+        // Ensure that the ID is a valid server initiated ID
+        if !id.is_client_initiated() {
+            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
+        }
+
+        Ok(())
     }
 }

--- a/src/proto/streams/buffer.rs
+++ b/src/proto/streams/buffer.rs
@@ -1,7 +1,5 @@
 use slab::Slab;
 
-use std::marker::PhantomData;
-
 /// Buffers frames for multiple streams.
 #[derive(Debug)]
 pub struct Buffer<T> {
@@ -10,9 +8,8 @@ pub struct Buffer<T> {
 
 /// A sequence of frames in a `Buffer`
 #[derive(Debug)]
-pub struct Deque<B> {
+pub struct Deque {
     indices: Option<Indices>,
-    _p: PhantomData<B>,
 }
 
 /// Tracks the head & tail for a sequence of frames in a `Buffer`.
@@ -36,11 +33,10 @@ impl<T> Buffer<T> {
     }
 }
 
-impl<T> Deque<T> {
+impl Deque {
     pub fn new() -> Self {
         Deque {
             indices: None,
-            _p: PhantomData,
         }
     }
 
@@ -48,7 +44,7 @@ impl<T> Deque<T> {
         self.indices.is_none()
     }
 
-    pub fn push_back(&mut self, buf: &mut Buffer<T>, value: T) {
+    pub fn push_back<T>(&mut self, buf: &mut Buffer<T>, value: T) {
         let key = buf.slab.insert(Slot {
             value,
             next: None,
@@ -68,7 +64,7 @@ impl<T> Deque<T> {
         }
     }
 
-    pub fn push_front(&mut self, buf: &mut Buffer<T>, value: T) {
+    pub fn push_front<T>(&mut self, buf: &mut Buffer<T>, value: T) {
         let key = buf.slab.insert(Slot {
             value,
             next: None,
@@ -88,7 +84,7 @@ impl<T> Deque<T> {
         }
     }
 
-    pub fn pop_front(&mut self, buf: &mut Buffer<T>) -> Option<T> {
+    pub fn pop_front<T>(&mut self, buf: &mut Buffer<T>) -> Option<T> {
         match self.indices {
             Some(mut idxs) => {
                 let mut slot = buf.slab.remove(idxs.head);
@@ -107,7 +103,7 @@ impl<T> Deque<T> {
         }
     }
 
-    pub fn peek_front<'a>(&self, buf: &'a Buffer<T>) -> Option<&'a T> {
+    pub fn peek_front<'a, T>(&self, buf: &'a Buffer<T>) -> Option<&'a T> {
         match self.indices {
             Some(idxs) => Some(&buf.slab[idxs.head].value),
             None => None,

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -82,9 +82,9 @@ impl Counts {
     ///
     /// If the stream state transitions to closed, this function will perform
     /// all necessary cleanup.
-    pub fn transition<F, B, U>(&mut self, mut stream: store::Ptr<B>, f: F) -> U
+    pub fn transition<F, U>(&mut self, mut stream: store::Ptr, f: F) -> U
     where
-        F: FnOnce(&mut Self, &mut store::Ptr<B>) -> U,
+        F: FnOnce(&mut Self, &mut store::Ptr) -> U,
     {
         let is_counted = stream.is_counted();
 
@@ -97,7 +97,7 @@ impl Counts {
     }
 
     // TODO: move this to macro?
-    pub fn transition_after<B>(&mut self, mut stream: store::Ptr<B>, is_counted: bool) {
+    pub fn transition_after(&mut self, mut stream: store::Ptr, is_counted: bool) {
         if stream.is_closed() {
             stream.unlink();
 

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -1,13 +1,13 @@
 use super::*;
 
-use std::marker::PhantomData;
 use std::usize;
 
 #[derive(Debug)]
-pub(super) struct Counts<P>
-where
-    P: Peer,
-{
+pub(super) struct Counts {
+    /// Acting as a client or server. This allows us to track which values to
+    /// inc / dec.
+    peer: peer::Dyn,
+
     /// Maximum number of locally initiated streams
     max_send_streams: usize,
 
@@ -19,23 +19,23 @@ where
 
     /// Current number of locally initiated streams
     num_recv_streams: usize,
-
-    _p: PhantomData<P>,
 }
 
-impl<P> Counts<P>
-where
-    P: Peer,
-{
+impl Counts {
     /// Create a new `Counts` using the provided configuration values.
-    pub fn new(config: &Config) -> Self {
+    pub fn new(peer: peer::Dyn, config: &Config) -> Self {
         Counts {
+            peer,
             max_send_streams: config.local_max_initiated.unwrap_or(usize::MAX),
             num_send_streams: 0,
             max_recv_streams: config.remote_max_initiated.unwrap_or(usize::MAX),
             num_recv_streams: 0,
-            _p: PhantomData,
         }
+    }
+
+    /// Returns the current peer
+    pub fn peer(&self) -> peer::Dyn {
+        self.peer
     }
 
     /// Returns true if the receive stream concurrency can be incremented
@@ -82,9 +82,9 @@ where
     ///
     /// If the stream state transitions to closed, this function will perform
     /// all necessary cleanup.
-    pub fn transition<F, B, U>(&mut self, mut stream: store::Ptr<B, P>, f: F) -> U
+    pub fn transition<F, B, U>(&mut self, mut stream: store::Ptr<B>, f: F) -> U
     where
-        F: FnOnce(&mut Self, &mut store::Ptr<B, P>) -> U,
+        F: FnOnce(&mut Self, &mut store::Ptr<B>) -> U,
     {
         let is_counted = stream.is_counted();
 
@@ -97,7 +97,7 @@ where
     }
 
     // TODO: move this to macro?
-    pub fn transition_after<B>(&mut self, mut stream: store::Ptr<B, P>, is_counted: bool) {
+    pub fn transition_after<B>(&mut self, mut stream: store::Ptr<B>, is_counted: bool) {
         if stream.is_closed() {
             stream.unlink();
 
@@ -114,7 +114,7 @@ where
     }
 
     fn dec_num_streams(&mut self, id: StreamId) {
-        if P::is_local_init(id) {
+        if self.peer.is_local_init(id) {
             self.num_send_streams -= 1;
         } else {
             self.num_recv_streams -= 1;

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -11,7 +11,7 @@ mod streams;
 
 pub(crate) use self::prioritize::Prioritized;
 pub(crate) use self::store::Key;
-pub(crate) use self::streams::{StreamRef, Streams};
+pub(crate) use self::streams::{StreamRef, OpaqueStreamRef, Streams};
 
 use self::buffer::Buffer;
 use self::counts::Counts;

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -1,5 +1,5 @@
 use super::*;
-use {client, frame, proto, server};
+use {frame, proto};
 use codec::{RecvError, UserError};
 use frame::{Reason, DEFAULT_INITIAL_WINDOW_SIZE};
 use proto::*;
@@ -10,10 +10,7 @@ use std::io;
 use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub(super) struct Recv<B, P>
-where
-    P: Peer,
-{
+pub(super) struct Recv<B> {
     /// Initial window size of remote initiated streams
     init_window_sz: WindowSize,
 
@@ -30,13 +27,13 @@ where
     last_processed_id: StreamId,
 
     /// Streams that have pending window updates
-    pending_window_updates: store::Queue<B, stream::NextWindowUpdate, P>,
+    pending_window_updates: store::Queue<B, stream::NextWindowUpdate>,
 
     /// New streams to be accepted
-    pending_accept: store::Queue<B, stream::NextAccept, P>,
+    pending_accept: store::Queue<B, stream::NextAccept>,
 
     /// Holds frames that are waiting to be read
-    buffer: Buffer<Event<P::Poll>>,
+    buffer: Buffer<Event>,
 
     /// Refused StreamId, this represents a frame that must be sent out.
     refused: Option<StreamId>,
@@ -48,8 +45,8 @@ where
 }
 
 #[derive(Debug)]
-pub(super) enum Event<T> {
-    Headers(T),
+pub(super) enum Event {
+    Headers(peer::PollMessage),
     Data(Bytes),
     Trailers(HeaderMap),
 }
@@ -60,12 +57,9 @@ struct Indices {
     tail: store::Key,
 }
 
-impl<B, P> Recv<B, P>
-where
-    P: Peer,
-{
-    pub fn new(config: &Config) -> Self {
-        let next_stream_id = if P::is_server() { 1 } else { 2 };
+impl<B> Recv<B> {
+    pub fn new(peer: peer::Dyn, config: &Config) -> Self {
+        let next_stream_id = if peer.is_server() { 1 } else { 2 };
 
         let mut flow = FlowControl::new();
 
@@ -106,11 +100,11 @@ where
     pub fn open(
         &mut self,
         id: StreamId,
-        counts: &mut Counts<P>,
+        counts: &mut Counts,
     ) -> Result<Option<StreamId>, RecvError> {
         assert!(self.refused.is_none());
 
-        self.ensure_can_open(id)?;
+        counts.peer().ensure_can_open(id)?;
 
         let next_id = self.next_stream_id()?;
         if id < next_id {
@@ -133,8 +127,8 @@ where
     pub fn recv_headers(
         &mut self,
         frame: frame::Headers,
-        stream: &mut store::Ptr<B, P>,
-        counts: &mut Counts<P>,
+        stream: &mut store::Ptr<B>,
+        counts: &mut Counts,
     ) -> Result<(), RecvError> {
         trace!("opening stream; init_window={}", self.init_window_sz);
         let is_initial = stream.state.recv_open(frame.is_end_stream())?;
@@ -168,7 +162,7 @@ where
             }
         }
 
-        let message = P::convert_poll_message(frame)?;
+        let message = counts.peer().convert_poll_message(frame)?;
 
         // Push the frame onto the stream's recv buffer
         stream
@@ -178,18 +172,53 @@ where
 
         // Only servers can receive a headers frame that initiates the stream.
         // This is verified in `Streams` before calling this function.
-        if P::is_server() {
+        if counts.peer().is_server() {
             self.pending_accept.push(stream);
         }
 
         Ok(())
     }
 
+    /// Called by the server to get the request
+    ///
+    /// TODO: Should this fn return `Result`?
+    pub fn take_request(&mut self, stream: &mut store::Ptr<B>)
+        -> Request<()>
+    {
+        use super::peer::PollMessage::*;
+
+        match stream.pending_recv.pop_front(&mut self.buffer) {
+            Some(Event::Headers(Server(request))) => request,
+            _ => panic!(),
+        }
+    }
+
+    /// Called by the client to get the response
+    pub fn poll_response(
+        &mut self,
+        stream: &mut store::Ptr<B>,
+    ) -> Poll<Response<()>, proto::Error> {
+        use super::peer::PollMessage::*;
+
+        // If the buffer is not empty, then the first frame must be a HEADERS
+        // frame or the user violated the contract.
+        match stream.pending_recv.pop_front(&mut self.buffer) {
+            Some(Event::Headers(Client(response))) => Ok(response.into()),
+            Some(_) => panic!("poll_response called after response returned"),
+            None => {
+                stream.state.ensure_recv_open()?;
+
+                stream.recv_task = Some(task::current());
+                Ok(Async::NotReady)
+            },
+        }
+    }
+
     /// Transition the stream based on receiving trailers
     pub fn recv_trailers(
         &mut self,
         frame: frame::Headers,
-        stream: &mut store::Ptr<B, P>,
+        stream: &mut store::Ptr<B>,
     ) -> Result<(), RecvError> {
         // Transition the state
         stream.state.recv_close()?;
@@ -216,7 +245,7 @@ where
     pub fn release_capacity(
         &mut self,
         capacity: WindowSize,
-        stream: &mut store::Ptr<B, P>,
+        stream: &mut store::Ptr<B>,
         task: &mut Option<Task>,
     ) -> Result<(), UserError> {
         trace!("release_capacity; size={}", capacity);
@@ -293,7 +322,7 @@ where
         }
     }
 
-    pub fn body_is_empty(&self, stream: &store::Ptr<B, P>) -> bool {
+    pub fn body_is_empty(&self, stream: &store::Ptr<B>) -> bool {
         if !stream.state.is_recv_closed() {
             return false;
         }
@@ -308,7 +337,7 @@ where
     pub fn recv_data(
         &mut self,
         frame: frame::Data,
-        stream: &mut store::Ptr<B, P>,
+        stream: &mut store::Ptr<B>,
     ) -> Result<(), RecvError> {
         let sz = frame.payload().len();
 
@@ -379,9 +408,9 @@ where
     pub fn recv_push_promise(
         &mut self,
         frame: frame::PushPromise,
-        send: &Send<B, P>,
+        send: &Send<B>,
         stream: store::Key,
-        store: &mut Store<B, P>,
+        store: &mut Store<B>,
     ) -> Result<(), RecvError> {
         // First, make sure that the values are legit
         self.ensure_can_reserve(frame.promised_id())?;
@@ -443,7 +472,7 @@ where
     pub fn recv_reset(
         &mut self,
         frame: frame::Reset,
-        stream: &mut Stream<B, P>,
+        stream: &mut Stream<B>,
     ) -> Result<(), RecvError> {
         let err = proto::Error::Proto(frame.reason());
 
@@ -454,28 +483,12 @@ where
     }
 
     /// Handle a received error
-    pub fn recv_err(&mut self, err: &proto::Error, stream: &mut Stream<B, P>) {
+    pub fn recv_err(&mut self, err: &proto::Error, stream: &mut Stream<B>) {
         // Receive an error
         stream.state.recv_err(err);
 
         // If a receiver is waiting, notify it
         stream.notify_recv();
-    }
-
-    /// Returns true if the remote peer can initiate a stream with the given ID.
-    fn ensure_can_open(&self, id: StreamId) -> Result<(), RecvError> {
-        if !P::is_server() {
-            // Remote is a server and cannot open streams. PushPromise is
-            // registered by reserving, so does not go through this path.
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
-        }
-
-        // Ensure that the ID is a valid server initiated ID
-        if !id.is_client_initiated() {
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
-        }
-
-        Ok(())
     }
 
     fn next_stream_id(&self) -> Result<StreamId, RecvError> {
@@ -487,14 +500,9 @@ where
     }
 
     /// Returns true if the remote peer can reserve a stream with the given ID.
-    fn ensure_can_reserve(&self, promised_id: StreamId) -> Result<(), RecvError> {
-        // TODO: Are there other rules?
-        if P::is_server() {
-            // The remote is a client and cannot reserve
-            trace!("recv_push_promise; error remote is client");
-            return Err(RecvError::Connection(Reason::PROTOCOL_ERROR));
-        }
-
+    fn ensure_can_reserve(&self, promised_id: StreamId)
+        -> Result<(), RecvError>
+    {
         if !promised_id.is_server_initiated() {
             trace!(
                 "recv_push_promise; error promised id is invalid {:?}",
@@ -539,7 +547,7 @@ where
 
     pub fn poll_complete<T>(
         &mut self,
-        store: &mut Store<B, P>,
+        store: &mut Store<B>,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<(), io::Error>
     where
@@ -589,7 +597,7 @@ where
     /// Send stream level window update
     pub fn send_stream_window_updates<T>(
         &mut self,
-        store: &mut Store<B, P>,
+        store: &mut Store<B>,
         dst: &mut Codec<T, Prioritized<B>>,
     ) -> Poll<(), io::Error>
     where
@@ -632,11 +640,11 @@ where
         }
     }
 
-    pub fn next_incoming(&mut self, store: &mut Store<B, P>) -> Option<store::Key> {
+    pub fn next_incoming(&mut self, store: &mut Store<B>) -> Option<store::Key> {
         self.pending_accept.pop(store).map(|ptr| ptr.key())
     }
 
-    pub fn poll_data(&mut self, stream: &mut Stream<B, P>) -> Poll<Option<Bytes>, proto::Error> {
+    pub fn poll_data(&mut self, stream: &mut Stream<B>) -> Poll<Option<Bytes>, proto::Error> {
         // TODO: Return error when the stream is reset
         match stream.pending_recv.pop_front(&mut self.buffer) {
             Some(Event::Data(payload)) => Ok(Some(payload).into()),
@@ -653,7 +661,7 @@ where
 
     pub fn poll_trailers(
         &mut self,
-        stream: &mut Stream<B, P>,
+        stream: &mut Stream<B>,
     ) -> Poll<Option<HeaderMap>, proto::Error> {
         match stream.pending_recv.pop_front(&mut self.buffer) {
             Some(Event::Trailers(trailers)) => Ok(Some(trailers).into()),
@@ -667,7 +675,7 @@ where
         }
     }
 
-    fn schedule_recv<T>(&mut self, stream: &mut Stream<B, P>) -> Poll<Option<T>, proto::Error> {
+    fn schedule_recv<T>(&mut self, stream: &mut Stream<B>) -> Poll<Option<T>, proto::Error> {
         if stream.state.ensure_recv_open()? {
             // Request to get notified once more frames arrive
             stream.recv_task = Some(task::current());
@@ -679,45 +687,9 @@ where
     }
 }
 
-impl<B> Recv<B, server::Peer>
-where
-    B: Buf,
-{
-    /// TODO: Should this fn return `Result`?
-    pub fn take_request(&mut self, stream: &mut store::Ptr<B, server::Peer>) -> Request<()> {
-        match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Headers(request)) => request,
-            _ => panic!(),
-        }
-    }
-}
-
-impl<B> Recv<B, client::Peer>
-where
-    B: Buf,
-{
-    pub fn poll_response(
-        &mut self,
-        stream: &mut store::Ptr<B, client::Peer>,
-    ) -> Poll<Response<()>, proto::Error> {
-        // If the buffer is not empty, then the first frame must be a HEADERS
-        // frame or the user violated the contract.
-        match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Headers(response)) => Ok(response.into()),
-            Some(_) => panic!("poll_response called after response returned"),
-            None => {
-                stream.state.ensure_recv_open()?;
-
-                stream.recv_task = Some(task::current());
-                Ok(Async::NotReady)
-            },
-        }
-    }
-}
-
 // ===== impl Event =====
 
-impl<T> Event<T> {
+impl Event {
     fn is_data(&self) -> bool {
         match *self {
             Event::Data(..) => true,

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -337,6 +337,7 @@ impl State {
         // TODO: Is this correct?
         match self.inner {
             Closed(Some(Cause::Proto(reason))) => Err(proto::Error::Proto(reason)),
+            Closed(Some(Cause::Canceled)) => Err(proto::Error::Proto(Reason::CANCEL)),
             Closed(Some(Cause::Io)) => Err(proto::Error::Io(io::ErrorKind::BrokenPipe.into())),
             Closed(None) | HalfClosedRemote(..) => Ok(false),
             _ => Ok(true),

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -74,6 +74,11 @@ enum Peer {
 enum Cause {
     Proto(Reason),
     Io,
+
+    /// The user droped all handles to the stream without explicitly canceling.
+    /// This indicates to the connection that a reset frame must be sent out
+    /// once the send queue has been flushed.
+    Canceled,
 }
 
 impl State {
@@ -238,8 +243,22 @@ impl State {
 
     /// Set the stream state to reset
     pub fn set_reset(&mut self, reason: Reason) {
-        debug_assert!(!self.is_reset());
         self.inner = Closed(Some(Cause::Proto(reason)));
+    }
+
+    /// Set the stream state to canceled
+    pub fn set_canceled(&mut self) {
+        debug_assert!(!self.is_closed());
+        self.inner = Closed(Some(Cause::Canceled));
+    }
+
+    pub fn is_canceled(&self) -> bool {
+        use self::Cause::Canceled;
+
+        match self.inner {
+            Closed(Some(Canceled)) => true,
+            _ => false,
+        }
     }
 
     /// Returns true if the stream is already reset.

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -9,22 +9,16 @@ use std::ops;
 
 /// Storage for streams
 #[derive(Debug)]
-pub(super) struct Store<B, P>
-where
-    P: Peer,
-{
-    slab: slab::Slab<(StoreId, Stream<B, P>)>,
+pub(super) struct Store<B> {
+    slab: slab::Slab<(StoreId, Stream<B>)>,
     ids: OrderMap<StreamId, (usize, StoreId)>,
     counter: StoreId,
 }
 
 /// "Pointer" to an entry in the store
-pub(super) struct Ptr<'a, B: 'a, P>
-where
-    P: Peer + 'a,
-{
+pub(super) struct Ptr<'a, B: 'a> {
     key: Key,
-    store: &'a mut Store<B, P>,
+    store: &'a mut Store<B>,
 }
 
 /// References an entry in the store.
@@ -37,24 +31,21 @@ pub(crate) struct Key {
 type StoreId = usize;
 
 #[derive(Debug)]
-pub(super) struct Queue<B, N, P>
-where
-    P: Peer,
-{
+pub(super) struct Queue<B, N> {
     indices: Option<store::Indices>,
-    _p: PhantomData<(B, N, P)>,
+    _p: PhantomData<(B, N)>,
 }
 
 pub(super) trait Next {
-    fn next<B, P: Peer>(stream: &Stream<B, P>) -> Option<Key>;
+    fn next<B>(stream: &Stream<B>) -> Option<Key>;
 
-    fn set_next<B, P: Peer>(stream: &mut Stream<B, P>, key: Option<Key>);
+    fn set_next<B>(stream: &mut Stream<B>, key: Option<Key>);
 
-    fn take_next<B, P: Peer>(stream: &mut Stream<B, P>) -> Option<Key>;
+    fn take_next<B>(stream: &mut Stream<B>) -> Option<Key>;
 
-    fn is_queued<B, P: Peer>(stream: &Stream<B, P>) -> bool;
+    fn is_queued<B>(stream: &Stream<B>) -> bool;
 
-    fn set_queued<B, P: Peer>(stream: &mut Stream<B, P>, val: bool);
+    fn set_queued<B>(stream: &mut Stream<B>, val: bool);
 }
 
 /// A linked list
@@ -64,37 +55,28 @@ struct Indices {
     pub tail: Key,
 }
 
-pub(super) enum Entry<'a, B: 'a, P: Peer + 'a> {
+pub(super) enum Entry<'a, B: 'a> {
     Occupied(OccupiedEntry<'a>),
-    Vacant(VacantEntry<'a, B, P>),
+    Vacant(VacantEntry<'a, B>),
 }
 
 pub(super) struct OccupiedEntry<'a> {
     ids: ordermap::OccupiedEntry<'a, StreamId, (usize, StoreId)>,
 }
 
-pub(super) struct VacantEntry<'a, B: 'a, P>
-where
-    P: Peer + 'a,
-{
+pub(super) struct VacantEntry<'a, B: 'a> {
     ids: ordermap::VacantEntry<'a, StreamId, (usize, StoreId)>,
-    slab: &'a mut slab::Slab<(StoreId, Stream<B, P>)>,
+    slab: &'a mut slab::Slab<(StoreId, Stream<B>)>,
     counter: &'a mut usize,
 }
 
-pub(super) trait Resolve<B, P>
-where
-    P: Peer,
-{
-    fn resolve(&mut self, key: Key) -> Ptr<B, P>;
+pub(super) trait Resolve<B> {
+    fn resolve(&mut self, key: Key) -> Ptr<B>;
 }
 
 // ===== impl Store =====
 
-impl<B, P> Store<B, P>
-where
-    P: Peer,
-{
+impl<B> Store<B> {
     pub fn new() -> Self {
         Store {
             slab: slab::Slab::new(),
@@ -103,7 +85,7 @@ where
         }
     }
 
-    pub fn find_mut(&mut self, id: &StreamId) -> Option<Ptr<B, P>> {
+    pub fn find_mut(&mut self, id: &StreamId) -> Option<Ptr<B>> {
         let key = match self.ids.get(id) {
             Some(key) => *key,
             None => return None,
@@ -118,7 +100,7 @@ where
         })
     }
 
-    pub fn insert(&mut self, id: StreamId, val: Stream<B, P>) -> Ptr<B, P> {
+    pub fn insert(&mut self, id: StreamId, val: Stream<B>) -> Ptr<B> {
         let store_id = self.counter;
         self.counter = self.counter.wrapping_add(1);
         let key = self.slab.insert((store_id, val));
@@ -133,7 +115,7 @@ where
         }
     }
 
-    pub fn find_entry(&mut self, id: StreamId) -> Entry<B, P> {
+    pub fn find_entry(&mut self, id: StreamId) -> Entry<B> {
         use self::ordermap::Entry::*;
 
         match self.ids.entry(id) {
@@ -150,7 +132,7 @@ where
 
     pub fn for_each<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(Ptr<B, P>) -> Result<(), E>,
+        F: FnMut(Ptr<B>) -> Result<(), E>,
     {
         let mut len = self.ids.len();
         let mut i = 0;
@@ -182,11 +164,8 @@ where
     }
 }
 
-impl<B, P> Resolve<B, P> for Store<B, P>
-where
-    P: Peer,
-{
-    fn resolve(&mut self, key: Key) -> Ptr<B, P> {
+impl<B> Resolve<B> for Store<B> {
+    fn resolve(&mut self, key: Key) -> Ptr<B> {
         Ptr {
             key: key,
             store: self,
@@ -194,11 +173,8 @@ where
     }
 }
 
-impl<B, P> ops::Index<Key> for Store<B, P>
-where
-    P: Peer,
-{
-    type Output = Stream<B, P>;
+impl<B> ops::Index<Key> for Store<B> {
+    type Output = Stream<B>;
 
     fn index(&self, key: Key) -> &Self::Output {
         let slot = self.slab.index(key.index);
@@ -207,10 +183,7 @@ where
     }
 }
 
-impl<B, P> ops::IndexMut<Key> for Store<B, P>
-where
-    P: Peer,
-{
+impl<B> ops::IndexMut<Key> for Store<B> {
     fn index_mut(&mut self, key: Key) -> &mut Self::Output {
         let slot = self.slab.index_mut(key.index);
         assert_eq!(slot.0, key.store_id);
@@ -218,10 +191,7 @@ where
     }
 }
 
-impl<B, P> Store<B, P>
-where
-    P: Peer,
-{
+impl<B> Store<B> {
     pub fn num_active_streams(&self) -> usize {
         self.ids.len()
     }
@@ -234,10 +204,9 @@ where
 
 // ===== impl Queue =====
 
-impl<B, N, P> Queue<B, N, P>
+impl<B, N> Queue<B, N>
 where
     N: Next,
-    P: Peer,
 {
     pub fn new() -> Self {
         Queue {
@@ -260,7 +229,7 @@ where
     /// Queue the stream.
     ///
     /// If the stream is already contained by the list, return `false`.
-    pub fn push(&mut self, stream: &mut store::Ptr<B, P>) -> bool {
+    pub fn push(&mut self, stream: &mut store::Ptr<B>) -> bool {
         trace!("Queue::push");
 
         if N::is_queued(stream) {
@@ -297,9 +266,9 @@ where
         true
     }
 
-    pub fn pop<'a, R>(&mut self, store: &'a mut R) -> Option<store::Ptr<'a, B, P>>
+    pub fn pop<'a, R>(&mut self, store: &'a mut R) -> Option<store::Ptr<'a, B>>
     where
-        R: Resolve<B, P>,
+        R: Resolve<B>,
     {
         if let Some(mut idxs) = self.indices {
             let mut stream = store.resolve(idxs.head);
@@ -324,10 +293,7 @@ where
 
 // ===== impl Ptr =====
 
-impl<'a, B: 'a, P> Ptr<'a, B, P>
-where
-    P: Peer,
-{
+impl<'a, B: 'a> Ptr<'a, B> {
     /// Returns the Key associated with the stream
     pub fn key(&self) -> Key {
         self.key
@@ -352,11 +318,8 @@ where
     }
 }
 
-impl<'a, B: 'a, P> Resolve<B, P> for Ptr<'a, B, P>
-where
-    P: Peer,
-{
-    fn resolve(&mut self, key: Key) -> Ptr<B, P> {
+impl<'a, B: 'a> Resolve<B> for Ptr<'a, B> {
+    fn resolve(&mut self, key: Key) -> Ptr<B> {
         Ptr {
             key: key,
             store: &mut *self.store,
@@ -364,22 +327,16 @@ where
     }
 }
 
-impl<'a, B: 'a, P> ops::Deref for Ptr<'a, B, P>
-where
-    P: Peer,
-{
-    type Target = Stream<B, P>;
+impl<'a, B: 'a> ops::Deref for Ptr<'a, B> {
+    type Target = Stream<B>;
 
-    fn deref(&self) -> &Stream<B, P> {
+    fn deref(&self) -> &Stream<B> {
         &self.store.slab[self.key.index].1
     }
 }
 
-impl<'a, B: 'a, P> ops::DerefMut for Ptr<'a, B, P>
-where
-    P: Peer,
-{
-    fn deref_mut(&mut self) -> &mut Stream<B, P> {
+impl<'a, B: 'a> ops::DerefMut for Ptr<'a, B> {
+    fn deref_mut(&mut self) -> &mut Stream<B> {
         &mut self.store.slab[self.key.index].1
     }
 }
@@ -398,11 +355,8 @@ impl<'a> OccupiedEntry<'a> {
 
 // ===== impl VacantEntry =====
 
-impl<'a, B, P> VacantEntry<'a, B, P>
-where
-    P: Peer,
-{
-    pub fn insert(self, value: Stream<B, P>) -> Key {
+impl<'a, B> VacantEntry<'a, B> {
+    pub fn insert(self, value: Stream<B>) -> Key {
         // Insert the value in the slab
         let store_id = *self.counter;
         *self.counter = store_id.wrapping_add(1);

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -14,10 +14,7 @@ use std::usize;
 /// (such as an accept queue), this is **not** tracked by a reference count.
 /// Thus, `ref_count` can be zero and the stream still has to be kept around.
 #[derive(Debug)]
-pub(super) struct Stream<B, P>
-where
-    P: Peer,
-{
+pub(super) struct Stream<B> {
     /// The h2 stream identifier
     pub id: StreamId,
 
@@ -88,13 +85,13 @@ where
     pub is_pending_window_update: bool,
 
     /// Frames pending for this stream to read
-    pub pending_recv: buffer::Deque<recv::Event<P::Poll>>,
+    pub pending_recv: buffer::Deque<recv::Event>,
 
     /// Task tracking receiving frames
     pub recv_task: Option<task::Task>,
 
     /// The stream's pending push promises
-    pub pending_push_promises: store::Queue<B, NextAccept, P>,
+    pub pending_push_promises: store::Queue<B, NextAccept>,
 
     /// Validate content-length headers
     pub content_length: ContentLength,
@@ -123,15 +120,12 @@ pub(super) struct NextWindowUpdate;
 #[derive(Debug)]
 pub(super) struct NextOpen;
 
-impl<B, P> Stream<B, P>
-where
-    P: Peer,
-{
+impl<B> Stream<B> {
     pub fn new(
         id: StreamId,
         init_send_window: WindowSize,
         init_recv_window: WindowSize,
-    ) -> Stream<B, P> {
+    ) -> Stream<B> {
         let mut send_flow = FlowControl::new();
         let mut recv_flow = FlowControl::new();
 
@@ -279,111 +273,111 @@ where
 }
 
 impl store::Next for NextAccept {
-    fn next<B, P: Peer>(stream: &Stream<B, P>) -> Option<store::Key> {
+    fn next<B>(stream: &Stream<B>) -> Option<store::Key> {
         stream.next_pending_accept
     }
 
-    fn set_next<B, P: Peer>(stream: &mut Stream<B, P>, key: Option<store::Key>) {
+    fn set_next<B, >(stream: &mut Stream<B>, key: Option<store::Key>) {
         stream.next_pending_accept = key;
     }
 
-    fn take_next<B, P: Peer>(stream: &mut Stream<B, P>) -> Option<store::Key> {
+    fn take_next<B>(stream: &mut Stream<B>) -> Option<store::Key> {
         stream.next_pending_accept.take()
     }
 
-    fn is_queued<B, P: Peer>(stream: &Stream<B, P>) -> bool {
+    fn is_queued<B>(stream: &Stream<B>) -> bool {
         stream.is_pending_accept
     }
 
-    fn set_queued<B, P: Peer>(stream: &mut Stream<B, P>, val: bool) {
+    fn set_queued<B>(stream: &mut Stream<B>, val: bool) {
         stream.is_pending_accept = val;
     }
 }
 
 impl store::Next for NextSend {
-    fn next<B, P: Peer>(stream: &Stream<B, P>) -> Option<store::Key> {
+    fn next<B>(stream: &Stream<B>) -> Option<store::Key> {
         stream.next_pending_send
     }
 
-    fn set_next<B, P: Peer>(stream: &mut Stream<B, P>, key: Option<store::Key>) {
+    fn set_next<B>(stream: &mut Stream<B>, key: Option<store::Key>) {
         stream.next_pending_send = key;
     }
 
-    fn take_next<B, P: Peer>(stream: &mut Stream<B, P>) -> Option<store::Key> {
+    fn take_next<B>(stream: &mut Stream<B>) -> Option<store::Key> {
         stream.next_pending_send.take()
     }
 
-    fn is_queued<B, P: Peer>(stream: &Stream<B, P>) -> bool {
+    fn is_queued<B>(stream: &Stream<B>) -> bool {
         stream.is_pending_send
     }
 
-    fn set_queued<B, P: Peer>(stream: &mut Stream<B, P>, val: bool) {
+    fn set_queued<B>(stream: &mut Stream<B>, val: bool) {
         stream.is_pending_send = val;
     }
 }
 
 impl store::Next for NextSendCapacity {
-    fn next<B, P: Peer>(stream: &Stream<B, P>) -> Option<store::Key> {
+    fn next<B>(stream: &Stream<B>) -> Option<store::Key> {
         stream.next_pending_send_capacity
     }
 
-    fn set_next<B, P: Peer>(stream: &mut Stream<B, P>, key: Option<store::Key>) {
+    fn set_next<B>(stream: &mut Stream<B>, key: Option<store::Key>) {
         stream.next_pending_send_capacity = key;
     }
 
-    fn take_next<B, P: Peer>(stream: &mut Stream<B, P>) -> Option<store::Key> {
+    fn take_next<B>(stream: &mut Stream<B>) -> Option<store::Key> {
         stream.next_pending_send_capacity.take()
     }
 
-    fn is_queued<B, P: Peer>(stream: &Stream<B, P>) -> bool {
+    fn is_queued<B>(stream: &Stream<B>) -> bool {
         stream.is_pending_send_capacity
     }
 
-    fn set_queued<B, P: Peer>(stream: &mut Stream<B, P>, val: bool) {
+    fn set_queued<B>(stream: &mut Stream<B>, val: bool) {
         stream.is_pending_send_capacity = val;
     }
 }
 
 impl store::Next for NextWindowUpdate {
-    fn next<B, P: Peer>(stream: &Stream<B, P>) -> Option<store::Key> {
+    fn next<B>(stream: &Stream<B>) -> Option<store::Key> {
         stream.next_window_update
     }
 
-    fn set_next<B, P: Peer>(stream: &mut Stream<B, P>, key: Option<store::Key>) {
+    fn set_next<B>(stream: &mut Stream<B>, key: Option<store::Key>) {
         stream.next_window_update = key;
     }
 
-    fn take_next<B, P: Peer>(stream: &mut Stream<B, P>) -> Option<store::Key> {
+    fn take_next<B>(stream: &mut Stream<B>) -> Option<store::Key> {
         stream.next_window_update.take()
     }
 
-    fn is_queued<B, P: Peer>(stream: &Stream<B, P>) -> bool {
+    fn is_queued<B>(stream: &Stream<B>) -> bool {
         stream.is_pending_window_update
     }
 
-    fn set_queued<B, P: Peer>(stream: &mut Stream<B, P>, val: bool) {
+    fn set_queued<B>(stream: &mut Stream<B>, val: bool) {
         stream.is_pending_window_update = val;
     }
 }
 
 impl store::Next for NextOpen {
-    fn next<B, P: Peer>(stream: &Stream<B, P>) -> Option<store::Key> {
+    fn next<B>(stream: &Stream<B>) -> Option<store::Key> {
         stream.next_open
     }
 
-    fn set_next<B, P: Peer>(stream: &mut Stream<B, P>, key: Option<store::Key>) {
+    fn set_next<B>(stream: &mut Stream<B>, key: Option<store::Key>) {
         stream.next_open = key;
     }
 
-    fn take_next<B, P: Peer>(stream: &mut Stream<B, P>) -> Option<store::Key> {
+    fn take_next<B>(stream: &mut Stream<B>) -> Option<store::Key> {
         stream.next_open.take()
     }
 
-    fn is_queued<B, P: Peer>(stream: &Stream<B, P>) -> bool {
+    fn is_queued<B>(stream: &Stream<B>) -> bool {
         stream.is_pending_open
     }
 
-    fn set_queued<B, P: Peer>(stream: &mut Stream<B, P>, val: bool) {
+    fn set_queued<B>(stream: &mut Stream<B>, val: bool) {
         stream.is_pending_open = val;
     }
 }

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -218,6 +218,15 @@ impl Stream {
             !self.is_pending_accept && !self.is_pending_window_update
     }
 
+    /// Returns true when the consumer of the stream has dropped all handles
+    /// (indicating no further interest in the stream) and the stream state is
+    /// not actually closed.
+    ///
+    /// In this case, a reset should be sent.
+    pub fn is_canceled_interest(&self) -> bool {
+        self.ref_count == 0 && !self.state.is_recv_closed()
+    }
+
     pub fn assign_capacity(&mut self, capacity: WindowSize) {
         debug_assert!(capacity > 0);
         self.send_capacity_inc = true;

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -527,7 +527,7 @@ where
 
         me.counts.transition(stream, |_, stream| {
             actions.send.send_reset(
-                reason, send_buffer, stream, &mut actions.task, true)
+                reason, send_buffer, stream, &mut actions.task)
         })
     }
 }
@@ -640,7 +640,7 @@ impl<B> StreamRef<B> {
 
         me.counts.transition(stream, |_, stream| {
             actions.send.send_reset(
-                reason, send_buffer, stream, &mut actions.task, true)
+                reason, send_buffer, stream, &mut actions.task)
         })
     }
 
@@ -877,7 +877,7 @@ impl Actions {
         }) = res
         {
             // Reset the stream.
-            self.send.send_reset(reason, buffer, stream, &mut self.task, true);
+            self.send.send_reset(reason, buffer, stream, &mut self.task);
             Ok(())
         } else {
             res

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,4 @@
+use {Stream, Body, ReleaseCapacity};
 use codec::{Codec, RecvError};
 use frame::{self, Reason, Settings, StreamId};
 use proto::{self, Connection, Prioritized};
@@ -7,8 +8,6 @@ use futures::{self, Async, Future, Poll};
 use http::{Request, Response};
 use tokio_io::{AsyncRead, AsyncWrite};
 use std::{convert, fmt, mem};
-
-pub use share::*;
 
 /// In progress H2 connection binding
 pub struct Handshake<T: AsyncRead + AsyncWrite, B: IntoBuf = Bytes> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -228,6 +228,11 @@ impl<B: IntoBuf> Respond<B> {
             .map_err(Into::into)
     }
 
+    /// Reset the stream
+    pub fn send_reset(&mut self, reason: Reason) {
+        self.inner.send_reset(reason)
+    }
+
     // TODO: Support reserving push promises.
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -270,7 +270,8 @@ impl<B: IntoBuf> Stream<B> {
         self.inner.send_trailers(trailers).map_err(Into::into)
     }
 
-    pub fn send_reset(mut self, reason: Reason) {
+    /// Reset the stream
+    pub fn send_reset(&mut self, reason: Reason) {
         self.inner.send_reset(reason)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,7 +28,7 @@ pub struct Builder {
 
 #[derive(Debug)]
 pub struct Stream<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf, Peer>,
+    inner: proto::StreamRef<B::Buf>,
 }
 
 pub struct Body<B: IntoBuf> {
@@ -37,7 +37,7 @@ pub struct Body<B: IntoBuf> {
 
 #[derive(Debug)]
 pub struct ReleaseCapacity<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf, Peer>,
+    inner: proto::StreamRef<B::Buf>,
 }
 
 #[derive(Debug)]
@@ -498,6 +498,10 @@ impl proto::Peer for Peer {
 
     fn is_server() -> bool {
         true
+    }
+
+    fn dyn() -> proto::DynPeer {
+        proto::DynPeer::Server
     }
 
     fn convert_send_message(

--- a/src/share.rs
+++ b/src/share.rs
@@ -12,13 +12,13 @@ pub struct Stream<B: IntoBuf> {
     inner: proto::StreamRef<B::Buf>,
 }
 
-pub struct Body<B: IntoBuf> {
-    inner: ReleaseCapacity<B>,
+pub struct Body {
+    inner: ReleaseCapacity,
 }
 
 #[derive(Debug)]
-pub struct ReleaseCapacity<B: IntoBuf> {
-    inner: proto::StreamRef<B::Buf>,
+pub struct ReleaseCapacity {
+    inner: proto::OpaqueStreamRef,
 }
 
 // ===== impl Stream =====
@@ -65,8 +65,8 @@ impl<B: IntoBuf> Stream<B> {
 
 // ===== impl Body =====
 
-impl<B: IntoBuf> Body<B> {
-    pub(crate) fn new(inner: ReleaseCapacity<B>) -> Self {
+impl Body {
+    pub(crate) fn new(inner: ReleaseCapacity) -> Self {
         Body { inner }
     }
 
@@ -75,7 +75,7 @@ impl<B: IntoBuf> Body<B> {
         self.inner.inner.body_is_empty()
     }
 
-    pub fn release_capacity(&mut self) -> &mut ReleaseCapacity<B> {
+    pub fn release_capacity(&mut self) -> &mut ReleaseCapacity {
         &mut self.inner
     }
 
@@ -87,7 +87,7 @@ impl<B: IntoBuf> Body<B> {
     }
 }
 
-impl<B: IntoBuf> futures::Stream for Body<B> {
+impl futures::Stream for Body {
     type Item = Bytes;
     type Error = ::Error;
 
@@ -96,10 +96,7 @@ impl<B: IntoBuf> futures::Stream for Body<B> {
     }
 }
 
-impl<B: IntoBuf> fmt::Debug for Body<B>
-where B: fmt::Debug,
-      B::Buf: fmt::Debug,
-{
+impl fmt::Debug for Body {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Body")
             .field("inner", &self.inner)
@@ -109,8 +106,8 @@ where B: fmt::Debug,
 
 // ===== impl ReleaseCapacity =====
 
-impl<B: IntoBuf> ReleaseCapacity<B> {
-    pub(crate) fn new(inner: proto::StreamRef<B::Buf>) -> Self {
+impl ReleaseCapacity {
+    pub(crate) fn new(inner: proto::OpaqueStreamRef) -> Self {
         ReleaseCapacity { inner }
     }
 
@@ -121,7 +118,7 @@ impl<B: IntoBuf> ReleaseCapacity<B> {
     }
 }
 
-impl<B: IntoBuf> Clone for ReleaseCapacity<B> {
+impl Clone for ReleaseCapacity {
     fn clone(&self) -> Self {
         let inner = self.inner.clone();
         ReleaseCapacity { inner }

--- a/src/share.rs
+++ b/src/share.rs
@@ -1,0 +1,129 @@
+use frame::Reason;
+use proto::{self, WindowSize};
+
+use bytes::{Bytes, IntoBuf};
+use futures::{self, Poll, Async};
+use http::{HeaderMap};
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct Stream<B: IntoBuf> {
+    inner: proto::StreamRef<B::Buf>,
+}
+
+pub struct Body<B: IntoBuf> {
+    inner: ReleaseCapacity<B>,
+}
+
+#[derive(Debug)]
+pub struct ReleaseCapacity<B: IntoBuf> {
+    inner: proto::StreamRef<B::Buf>,
+}
+
+// ===== impl Stream =====
+
+impl<B: IntoBuf> Stream<B> {
+    pub(crate) fn new(inner: proto::StreamRef<B::Buf>) -> Self {
+        Stream { inner }
+    }
+
+    /// Request capacity to send data
+    pub fn reserve_capacity(&mut self, capacity: usize) {
+        // TODO: Check for overflow
+        self.inner.reserve_capacity(capacity as WindowSize)
+    }
+
+    /// Returns the stream's current send capacity.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity() as usize
+    }
+
+    /// Request to be notified when the stream's capacity increases
+    pub fn poll_capacity(&mut self) -> Poll<Option<usize>, ::Error> {
+        let res = try_ready!(self.inner.poll_capacity());
+        Ok(Async::Ready(res.map(|v| v as usize)))
+    }
+
+    /// Send a single data frame
+    pub fn send_data(&mut self, data: B, end_of_stream: bool) -> Result<(), ::Error> {
+        self.inner
+            .send_data(data.into_buf(), end_of_stream)
+            .map_err(Into::into)
+    }
+
+    /// Send trailers
+    pub fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), ::Error> {
+        self.inner.send_trailers(trailers).map_err(Into::into)
+    }
+
+    /// Reset the stream
+    pub fn send_reset(&mut self, reason: Reason) {
+        self.inner.send_reset(reason)
+    }
+}
+
+// ===== impl Body =====
+
+impl<B: IntoBuf> Body<B> {
+    pub(crate) fn new(inner: ReleaseCapacity<B>) -> Self {
+        Body { inner }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        // If the recv side is closed and the receive queue is empty, the body is empty.
+        self.inner.inner.body_is_empty()
+    }
+
+    pub fn release_capacity(&mut self) -> &mut ReleaseCapacity<B> {
+        &mut self.inner
+    }
+
+    /// Poll trailers
+    ///
+    /// This function **must** not be called until `Body::poll` returns `None`.
+    pub fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, ::Error> {
+        self.inner.inner.poll_trailers().map_err(Into::into)
+    }
+}
+
+impl<B: IntoBuf> futures::Stream for Body<B> {
+    type Item = Bytes;
+    type Error = ::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.inner.inner.poll_data().map_err(Into::into)
+    }
+}
+
+impl<B: IntoBuf> fmt::Debug for Body<B>
+where B: fmt::Debug,
+      B::Buf: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Body")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+// ===== impl ReleaseCapacity =====
+
+impl<B: IntoBuf> ReleaseCapacity<B> {
+    pub(crate) fn new(inner: proto::StreamRef<B::Buf>) -> Self {
+        ReleaseCapacity { inner }
+    }
+
+    pub fn release_capacity(&mut self, sz: usize) -> Result<(), ::Error> {
+        self.inner
+            .release_capacity(sz as proto::WindowSize)
+            .map_err(Into::into)
+    }
+}
+
+impl<B: IntoBuf> Clone for ReleaseCapacity<B> {
+    fn clone(&self) -> Self {
+        let inner = self.inner.clone();
+        ReleaseCapacity { inner }
+    }
+}

--- a/tests/support/util.rs
+++ b/tests/support/util.rs
@@ -8,7 +8,7 @@ pub fn byte_str(s: &str) -> String<Bytes> {
     String::try_from(Bytes::from(s)).unwrap()
 }
 
-pub fn wait_for_capacity(stream: h2::Stream<Bytes>, target: usize) -> WaitForCapacity {
+pub fn wait_for_capacity(stream: h2::SendStream<Bytes>, target: usize) -> WaitForCapacity {
     WaitForCapacity {
         stream: Some(stream),
         target: target,
@@ -16,18 +16,18 @@ pub fn wait_for_capacity(stream: h2::Stream<Bytes>, target: usize) -> WaitForCap
 }
 
 pub struct WaitForCapacity {
-    stream: Option<h2::Stream<Bytes>>,
+    stream: Option<h2::SendStream<Bytes>>,
     target: usize,
 }
 
 impl WaitForCapacity {
-    fn stream(&mut self) -> &mut h2::Stream<Bytes> {
+    fn stream(&mut self) -> &mut h2::SendStream<Bytes> {
         self.stream.as_mut().unwrap()
     }
 }
 
 impl Future for WaitForCapacity {
-    type Item = h2::Stream<Bytes>;
+    type Item = h2::SendStream<Bytes>;
     type Error = ();
 
     fn poll(&mut self) -> Poll<Self::Item, ()> {

--- a/tests/support/util.rs
+++ b/tests/support/util.rs
@@ -1,4 +1,4 @@
-use h2::client;
+use h2;
 
 use super::string::{String, TryFrom};
 use bytes::Bytes;
@@ -8,7 +8,7 @@ pub fn byte_str(s: &str) -> String<Bytes> {
     String::try_from(Bytes::from(s)).unwrap()
 }
 
-pub fn wait_for_capacity(stream: client::Stream<Bytes>, target: usize) -> WaitForCapacity {
+pub fn wait_for_capacity(stream: h2::Stream<Bytes>, target: usize) -> WaitForCapacity {
     WaitForCapacity {
         stream: Some(stream),
         target: target,
@@ -16,18 +16,18 @@ pub fn wait_for_capacity(stream: client::Stream<Bytes>, target: usize) -> WaitFo
 }
 
 pub struct WaitForCapacity {
-    stream: Option<client::Stream<Bytes>>,
+    stream: Option<h2::Stream<Bytes>>,
     target: usize,
 }
 
 impl WaitForCapacity {
-    fn stream(&mut self) -> &mut client::Stream<Bytes> {
+    fn stream(&mut self) -> &mut h2::Stream<Bytes> {
         self.stream.as_mut().unwrap()
     }
 }
 
 impl Future for WaitForCapacity {
-    type Item = client::Stream<Bytes>;
+    type Item = h2::Stream<Bytes>;
     type Error = ();
 
     fn poll(&mut self) -> Poll<Self::Item, ()> {


### PR DESCRIPTION
This PR provides a bunch of API cleanup

### Unifying `client` & `server` types.

The first step is to rid of the internal `P: Peer` generic.

### Removing `B` generic

All public API types that do not work with the send data frame type are no longer generic.

### `&mut self` for `send_reset`

While calling this function is the last thing that should be done with
the instance, the intent of the h2 library is not to be used directly by
users, but to be used as an implementation detail by other libraries.

Requiring `self` on `send_reset` is pretty annoying when calling the
function from inside a `Future` implementation. Also, all the other fns
on the type take `&mut self`.