### PR TITLE
Add test and assertion for idle state handling

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -628,12 +628,10 @@ impl Prioritize {
                     };
 
                     trace!("pop_frame; frame={:?}", frame);
-                    
-                    if let Frame::Headers(_) = frame {
-                        if stream.state.is_idle() {
-                            debug_assert!(stream.id > self.last_opened_id);
-                            self.last_opened_id = stream.id;
-                        }
+
+                    if stream.state.is_idle() {
+                        debug_assert!(stream.id > self.last_opened_id);
+                        self.last_opened_id = stream.id;
                     }
 
                     if !stream.pending_send.is_empty() || stream.state.is_canceled() {

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -629,7 +629,7 @@ impl Prioritize {
 
                     trace!("pop_frame; frame={:?}", frame);
 
-                    if stream.state.is_idle() {
+                    if cfg!(debug_assertions) && stream.state.is_idle() {
                         debug_assert!(stream.id > self.last_opened_id);
                         self.last_opened_id = stream.id;
                     }

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -21,12 +21,9 @@ use std::io;
 /// IDs, some mechanism would be necessary to ensure that the lowest-numberedh]
 /// idle stream is opened first.
 #[derive(Debug)]
-pub(super) struct Prioritize<B, P>
-where
-    P: Peer,
-{
+pub(super) struct Prioritize {
     /// Queue of streams waiting for socket capacity to send a frame.
-    pending_send: store::Queue<B, stream::NextSend, P>,
+    pending_send: store::Queue<stream::NextSend>,
 
     /// Queue of streams waiting for window capacity to produce data.
     pending_capacity: store::Queue<stream::NextSendCapacity>,

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -58,6 +58,11 @@ impl Send {
 
         let end_stream = frame.is_end_stream();
 
+        assert!(frame.stream_id() >=
+            self.next_stream_id
+                .map_err(|_| OverflowedStreamId)?
+        );
+
         // Update the state
         stream.state.send_open(end_stream)?;
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -58,11 +58,6 @@ impl Send {
 
         let end_stream = frame.is_end_stream();
 
-        assert!(frame.stream_id() >=
-            self.next_stream_id
-                .map_err(|_| OverflowedStreamId)?
-        );
-
         // Update the state
         stream.state.send_open(end_stream)?;
 

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -331,6 +331,13 @@ impl State {
         }
     }
 
+    pub fn is_idle(&self) -> bool {
+        match self.inner {
+            Idle => true,
+            _ => false,
+        }
+    }
+
     pub fn ensure_recv_open(&self) -> Result<bool, proto::Error> {
         use std::io;
 

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -367,6 +367,60 @@ fn recv_goaway_finishes_processed_streams() {
     h2.join(srv).wait().expect("wait");
 }
 
+#[test]
+fn skipped_stream_ids_are_implicitly_closed() {
+    let _ = ::env_logger::init();
+    let (io, srv) = mock::new();
+
+    let srv = srv
+        .assert_client_handshake()
+        .expect("handshake")
+        .recv_settings()
+        .recv_frame(frames::headers(5)
+            .request("GET", "https://example.com/")
+            .eos(),
+        )
+        // send the response on a lower-numbered stream, which should be
+        // implicitly closed.
+        .send_frame(frames::headers(3).response(200));
+
+        let h2 = Client::builder()
+            .initial_stream_id(5)
+            .handshake::<_, Bytes>(io)
+            .expect("handshake")
+            .and_then(|(mut client, h2)| {
+                let request = Request::builder()
+                    .method(Method::GET)
+                    .uri("https://example.com/")
+                    .body(())
+                    .unwrap();
+
+                let req = client.send_request(request, true)
+                    .unwrap()
+                    .0.then(|res| {
+                        let err = res.unwrap_err();
+                        assert_eq!(
+                            err.to_string(),
+                            "protocol error: unspecific protocol error detected");
+                        Ok::<(), ()>(())
+                    });
+                    // client should see a conn error
+                    let conn = h2.then(|res| {
+                        let err = res.unwrap_err();
+                        assert_eq!(
+                            err.to_string(),
+                            "protocol error: unspecific protocol error detected"
+                        );
+                        Ok::<(), ()>(())
+                    });
+                    conn.unwrap().join(req)
+            });
+
+
+        h2.join(srv).wait().expect("wait");
+
+}
+
 /*
 #[test]
 fn send_data_after_headers_eos() {


### PR DESCRIPTION
I've added a unit test ensuring that we don't initialize streams in the idle state such that they may be moved into reserved/open out of order. I've also added an assertion in `Prioritize::pop_frame` that the stream ID of any headers frame that opens a new stream is greater than all previously sent stream IDs.

Closes #11