### PR TITLE
Make panic message in unreachable!() explain why

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -601,7 +601,12 @@ impl Prioritize {
                                 }
                             }))
                         },
-                        Some(frame) => frame.map(|_| unreachable!()),
+                        Some(frame) => frame.map(|_|
+                            unreachable!(
+                                "Frame::map closure will only be called \
+                                 on DATA frames."
+                             )
+                        ),
                         None => {
                             assert!(stream.state.is_canceled());
                             stream.state.set_reset(Reason::CANCEL);


### PR DESCRIPTION
I was somewhat confused by `frame.map(|_| unreachable!())` here, so after @seanmonstar explained to me why this code was unreachable, I thought I'd add a message to the `unreachable!()` macro to prevent future confusion.