### PR TITLE
Loosen some bounds.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -67,7 +67,7 @@ const PREFACE: [u8; 24] = *b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 impl<T> Server<T, Bytes>
 where
-    T: AsyncRead + AsyncWrite + 'static,
+    T: AsyncRead + AsyncWrite,
 {
     /// Bind an H2 server connection.
     ///
@@ -87,7 +87,7 @@ impl Server<(), Bytes> {
 
 impl<T, B> Server<T, B>
 where
-    T: AsyncRead + AsyncWrite + 'static,
+    T: AsyncRead + AsyncWrite,
     B: IntoBuf + 'static,
     B::Buf: 'static,
 {
@@ -126,7 +126,7 @@ where
 
 impl<T, B> futures::Stream for Server<T, B>
 where
-    T: AsyncRead + AsyncWrite + 'static,
+    T: AsyncRead + AsyncWrite,
     B: IntoBuf + 'static,
     B::Buf: 'static,
 {
@@ -206,7 +206,7 @@ impl Builder {
     /// handshake has been completed.
     pub fn handshake<T, B>(&self, io: T) -> Handshake<T, B>
     where
-        T: AsyncRead + AsyncWrite + 'static,
+        T: AsyncRead + AsyncWrite,
         B: IntoBuf + 'static,
     {
         Server::handshake2(io, self.settings.clone())

--- a/src/server.rs
+++ b/src/server.rs
@@ -88,7 +88,7 @@ impl Server<(), Bytes> {
 impl<T, B> Server<T, B>
 where
     T: AsyncRead + AsyncWrite,
-    B: IntoBuf + 'static,
+    B: IntoBuf,
     B::Buf: 'static,
 {
     fn handshake2(io: T, settings: Settings) -> Handshake<T, B> {
@@ -127,7 +127,7 @@ where
 impl<T, B> futures::Stream for Server<T, B>
 where
     T: AsyncRead + AsyncWrite,
-    B: IntoBuf + 'static,
+    B: IntoBuf,
     B::Buf: 'static,
 {
     type Item = (Request<RecvStream>, Respond<B>);
@@ -207,7 +207,8 @@ impl Builder {
     pub fn handshake<T, B>(&self, io: T) -> Handshake<T, B>
     where
         T: AsyncRead + AsyncWrite,
-        B: IntoBuf + 'static,
+        B: IntoBuf,
+        B::Buf: 'static,
     {
         Server::handshake2(io, self.settings.clone())
     }


### PR DESCRIPTION
Remove `'static` bounds from some types. These are not necessary anymore now that the server handshake has been unboxed.