### PR TITLE
Expose h2::Error::reason

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,9 +34,9 @@ impl Error {
     ///
     /// This is either an error received by the peer or caused by an invalid
     /// action taken by the peer (i.e. a protocol error).
-    pub fn reason(&self) -> Option<&Reason> {
+    pub fn reason(&self) -> Option<Reason> {
         match self.kind {
-            Kind::Proto(ref reason) => Some(reason),
+            Kind::Proto(ref reason) => Some(*reason),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,19 @@ enum Kind {
 
 // ===== impl Error =====
 
+impl Error {
+    /// If the error was caused by the remote peer, the error reason.
+    ///
+    /// This is either an error received by the peer or caused by an invalid
+    /// action taken by the peer (i.e. a protocol error).
+    pub fn reason(&self) -> Option<&Reason> {
+        match self.kind {
+            Kind::Proto(ref reason) => Some(reason),
+            _ => None,
+        }
+    }
+}
+
 impl From<proto::Error> for Error {
     fn from(src: proto::Error) -> Error {
         use proto::Error::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ impl Error {
     /// action taken by the peer (i.e. a protocol error).
     pub fn reason(&self) -> Option<Reason> {
         match self.kind {
-            Kind::Proto(ref reason) => Some(*reason),
+            Kind::Proto(reason) => Some(reason),
             _ => None,
         }
     }


### PR DESCRIPTION
When an h2 error code is known, applications may care to know about the
specific error. For example, an application may want to report per-code
metrics or handle `ENHANCE_YOUR_CALM` specially.