### PR TITLE
reject connection-specific headers

### DIFF
--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -44,6 +44,9 @@ pub enum UserError {
     ///
     /// A new connection is needed.
     OverflowedStreamId,
+
+    /// Illegal headers, such as connection-specific headers.
+    MalformedHeaders,
 }
 
 // ===== impl RecvError =====
@@ -121,6 +124,7 @@ impl error::Error for UserError {
             Rejected => "rejected",
             ReleaseCapacityTooBig => "release capacity too big",
             OverflowedStreamId => "stream ID overflowed",
+            MalformedHeaders => "malformed headers",
         }
     }
 }

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -635,7 +635,12 @@ impl HeaderBlock {
                     // Connection level header fields are not supported and must
                     // result in a protocol error.
 
-                    if name == header::CONNECTION {
+                    if name == header::CONNECTION
+                        || name == header::TRANSFER_ENCODING
+                        || name == header::UPGRADE
+                        || name == "keep-alive"
+                        || name == "proxy-connection"
+                    {
                         trace!("load_hpack; connection level header");
                         malformed = true;
                     } else if name == header::TE && value != "trailers" {

--- a/tests/support/frames.rs
+++ b/tests/support/frames.rs
@@ -126,6 +126,17 @@ impl Mock<frame::Headers> {
         Mock(frame)
     }
 
+    pub fn field<K, V>(self, key: K, value: V) -> Self
+    where
+        K: HttpTryInto<http::header::HeaderName>,
+        V: HttpTryInto<http::header::HeaderValue>,
+    {
+        let (id, pseudo, mut fields) = self.into_parts();
+        fields.insert(key.try_into().unwrap(), value.try_into().unwrap());
+        let frame = frame::Headers::new(id, pseudo, fields);
+        Mock(frame)
+    }
+
     pub fn eos(mut self) -> Self {
         self.0.set_end_stream();
         self


### PR DESCRIPTION
- When receiving, return a PROTOCOL_ERROR.
- When sending, return a user error about malformed headers.

While #36 mentions stripping the headers, this PR actually returns a `UserError` instead.

Closes #36