### PR TITLE
Client should validate request URI.

### DIFF
--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -47,6 +47,9 @@ pub enum UserError {
 
     /// Illegal headers, such as connection-specific headers.
     MalformedHeaders,
+
+    /// Request submitted with relative URI.
+    MissingUriSchemeAndAuthority,
 }
 
 // ===== impl RecvError =====
@@ -125,6 +128,7 @@ impl error::Error for UserError {
             ReleaseCapacityTooBig => "release capacity too big",
             OverflowedStreamId => "stream ID overflowed",
             MalformedHeaders => "malformed headers",
+            MissingUriSchemeAndAuthority => "request URI missing scheme and authority",
         }
     }
 }

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -63,6 +63,7 @@ pub struct Continuation {
     headers: Iter,
 }
 
+// TODO: These fields shouldn't be `pub`
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Pseudo {
     // Request
@@ -405,10 +406,6 @@ impl Pseudo {
     pub fn request(method: Method, uri: Uri) -> Self {
         let parts = uri::Parts::from(uri);
 
-        fn to_string(src: Bytes) -> String<Bytes> {
-            unsafe { String::from_utf8_unchecked(src) }
-        }
-
         let path = parts
             .path_and_query
             .map(|v| v.into())
@@ -426,7 +423,7 @@ impl Pseudo {
         //
         // TODO: Scheme must be set...
         if let Some(scheme) = parts.scheme {
-            pseudo.set_scheme(to_string(scheme.into()));
+            pseudo.set_scheme(scheme);
         }
 
         // If the URI includes an authority component, add it to the pseudo
@@ -448,13 +445,17 @@ impl Pseudo {
         }
     }
 
-    pub fn set_scheme(&mut self, scheme: String<Bytes>) {
-        self.scheme = Some(scheme);
+    pub fn set_scheme(&mut self, scheme: uri::Scheme) {
+        self.scheme = Some(to_string(scheme.into()));
     }
 
     pub fn set_authority(&mut self, authority: String<Bytes>) {
         self.authority = Some(authority);
     }
+}
+
+fn to_string(src: Bytes) -> String<Bytes> {
+    unsafe { String::from_utf8_unchecked(src) }
 }
 
 // ===== impl Iter =====

--- a/src/proto/peer.rs
+++ b/src/proto/peer.rs
@@ -8,17 +8,12 @@ use std::fmt;
 
 /// Either a Client or a Server
 pub trait Peer {
-    /// Message type sent into the transport
-    type Send;
-
     /// Message type polled from the transport
     type Poll: fmt::Debug;
 
     fn dyn() -> Dyn;
 
     fn is_server() -> bool;
-
-    fn convert_send_message(id: StreamId, headers: Self::Send, end_of_stream: bool) -> Headers;
 
     fn convert_poll_message(headers: Headers) -> Result<Self::Poll, RecvError>;
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -74,8 +74,6 @@ impl Send {
             }
         }
 
-
-
         let end_stream = frame.is_end_stream();
 
         // Update the state

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -494,7 +494,8 @@ where
             }
 
             // Convert the message
-            let headers = client::Peer::convert_send_message(stream_id, request, end_of_stream);
+            let headers = client::Peer::convert_send_message(
+                stream_id, request, end_of_stream)?;
 
             let mut stream = me.store.insert(stream.id, stream);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -375,23 +375,12 @@ impl<T, B> fmt::Debug for Handshake<T, B>
     }
 }
 
-impl proto::Peer for Peer {
-    type Send = Response<()>;
-    type Poll = Request<()>;
-
-    fn is_server() -> bool {
-        true
-    }
-
-    fn dyn() -> proto::DynPeer {
-        proto::DynPeer::Server
-    }
-
-    fn convert_send_message(
+impl Peer {
+    pub fn convert_send_message(
         id: StreamId,
-        response: Self::Send,
-        end_of_stream: bool,
-    ) -> frame::Headers {
+        response: Response<()>,
+        end_of_stream: bool) -> frame::Headers
+    {
         use http::response::Parts;
 
         // Extract the components of the HTTP request
@@ -416,6 +405,18 @@ impl proto::Peer for Peer {
         }
 
         frame
+    }
+}
+
+impl proto::Peer for Peer {
+    type Poll = Request<()>;
+
+    fn is_server() -> bool {
+        true
+    }
+
+    fn dyn() -> proto::DynPeer {
+        proto::DynPeer::Server
     }
 
     fn convert_poll_message(headers: frame::Headers) -> Result<Self::Poll, RecvError> {

--- a/tests/support/frames.rs
+++ b/tests/support/frames.rs
@@ -137,6 +137,16 @@ impl Mock<frame::Headers> {
         Mock(frame)
     }
 
+    pub fn scheme(self, value: &str) -> Self
+    {
+        let (id, mut pseudo, fields) = self.into_parts();
+        let value = value.parse().unwrap();
+
+        pseudo.set_scheme(value);
+
+        Mock(frame::Headers::new(id, pseudo, fields))
+    }
+
     pub fn eos(mut self) -> Self {
         self.0.set_end_stream();
         self

--- a/tests/support/prelude.rs
+++ b/tests/support/prelude.rs
@@ -32,7 +32,7 @@ pub use self::futures::{Future, IntoFuture, Sink, Stream};
 pub use super::future_ext::{FutureExt, Unwrap};
 
 // Re-export HTTP types
-pub use self::http::{HeaderMap, Method, Request, Response, StatusCode};
+pub use self::http::{HeaderMap, Method, Request, Response, StatusCode, Version};
 
 pub use self::bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
 


### PR DESCRIPTION
This patch adds checks for the request URI and rejects invalid URIs. In
the case of forwarding an HTTP 1.1 request with a path, an "http" pseudo
header is added to satisfy the HTTP/2.0 spec.

`convert_send_message` is removed from the `Peer` trait as it is not
needed to be generic. The client version now returns an error if the request
is invalid.

This PR depends on https://github.com/hyperium/http/pull/147.

Closes #179