### PR TITLE
Remove most struct level bounds on handshake types

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ use std::{convert, fmt, mem};
 
 /// In progress H2 connection binding
 #[must_use = "futures do nothing unless polled"]
-pub struct Handshake<T: AsyncRead + AsyncWrite, B: IntoBuf = Bytes> {
+pub struct Handshake<T, B: IntoBuf = Bytes> {
     /// SETTINGS frame that will be sent once the connection is established.
     settings: Settings,
     /// The current state of the handshake.


### PR DESCRIPTION
As the title says. This removes all but one struct level bound on the client/server `Handshake` future struct.