### PR TITLE
Don't panic on poll_trailers called out of order.

### DIFF
--- a/src/share.rs
+++ b/src/share.rs
@@ -98,8 +98,6 @@ impl RecvStream {
     }
 
     /// Poll trailers
-    ///
-    /// This function **must** not be called until `Body::poll` returns `None`.
     pub fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, ::Error> {
         self.inner.inner.poll_trailers().map_err(Into::into)
     }


### PR DESCRIPTION
This patch removes a panic in `poll_trailers` that is triggered if
`poll_trailers` is called before `poll_data` returns `None`.

This is done by always trying to notify the receive task when
`poll_data` returns None and there already is pending trailers.