### PR TITLE
Misc renames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
   - rust: nightly
   - rust: stable
     before_deploy: cargo doc --no-deps
+  allow_failures:
+    - rust: nightly
 
 install:
   - bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Next, add this to your crate:
 ```rust
 extern crate h2;
 
-use h2::server::Server;
+use h2::server::Connection;
 
 fn main() {
     // ...

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -8,7 +8,7 @@ extern crate tokio_core;
 extern crate tokio_rustls;
 extern crate webpki_roots;
 
-use h2::client::Connection;
+use h2::client;
 
 use futures::*;
 use http::{Method, Request};
@@ -64,10 +64,10 @@ pub fn main() {
                 let tls = io_dump::Dump::to_stdout(tls);
 
                 println!("Starting client handshake");
-                Connection::handshake(tls)
+                client::handshake(tls)
             })
             .then(|res| {
-                let (h2, mut client) = res.unwrap();
+                let (mut client, h2) = res.unwrap();
 
                 let request = Request::builder()
                     .method(Method::GET)

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -8,7 +8,7 @@ extern crate tokio_core;
 extern crate tokio_rustls;
 extern crate webpki_roots;
 
-use h2::client::Client;
+use h2::client::Connection;
 
 use futures::*;
 use http::{Method, Request};
@@ -64,10 +64,10 @@ pub fn main() {
                 let tls = io_dump::Dump::to_stdout(tls);
 
                 println!("Starting client handshake");
-                Client::handshake(tls)
+                Connection::handshake(tls)
             })
             .then(|res| {
-                let (mut client, h2) = res.unwrap();
+                let (h2, mut client) = res.unwrap();
 
                 let request = Request::builder()
                     .method(Method::GET)

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,7 @@ extern crate http;
 extern crate io_dump;
 extern crate tokio_core;
 
-use h2::client::{Client};
+use h2::client::Connection;
 use h2::RecvStream;
 
 use futures::*;
@@ -55,9 +55,9 @@ pub fn main() {
 
     let tcp = tcp.then(|res| {
         let tcp = io_dump::Dump::to_stdout(res.unwrap());
-        Client::handshake(tcp)
+        Connection::handshake(tcp)
     }).then(|res| {
-            let (mut client, h2) = res.unwrap();
+            let (h2, mut client) = res.unwrap();
 
             println!("sending request");
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,7 @@ extern crate http;
 extern crate io_dump;
 extern crate tokio_core;
 
-use h2::client::Connection;
+use h2::client;
 use h2::RecvStream;
 
 use futures::*;
@@ -55,9 +55,9 @@ pub fn main() {
 
     let tcp = tcp.then(|res| {
         let tcp = io_dump::Dump::to_stdout(res.unwrap());
-        Connection::handshake(tcp)
+        client::handshake(tcp)
     }).then(|res| {
-            let (h2, mut client) = res.unwrap();
+            let (mut client, h2) = res.unwrap();
 
             println!("sending request");
 

--- a/examples/server-tr.rs
+++ b/examples/server-tr.rs
@@ -5,7 +5,7 @@ extern crate h2;
 extern crate http;
 extern crate tokio_core;
 
-use h2::server::Connection;
+use h2::server;
 
 use bytes::*;
 use futures::*;
@@ -28,7 +28,7 @@ pub fn main() {
         // let socket = io_dump::Dump::to_stdout(socket);
 
 
-        let connection = Connection::handshake(socket)
+        let connection = server::handshake(socket)
             .and_then(|conn| {
                 println!("H2 connection bound");
 

--- a/examples/server-tr.rs
+++ b/examples/server-tr.rs
@@ -5,7 +5,7 @@ extern crate h2;
 extern crate http;
 extern crate tokio_core;
 
-use h2::server::Server;
+use h2::server::Connection;
 
 use bytes::*;
 use futures::*;
@@ -28,7 +28,7 @@ pub fn main() {
         // let socket = io_dump::Dump::to_stdout(socket);
 
 
-        let connection = Server::handshake(socket)
+        let connection = Connection::handshake(socket)
             .and_then(|conn| {
                 println!("H2 connection bound");
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,7 +5,7 @@ extern crate h2;
 extern crate http;
 extern crate tokio_core;
 
-use h2::server::Server;
+use h2::server::Connection;
 
 use bytes::*;
 use futures::*;
@@ -27,7 +27,7 @@ pub fn main() {
     let server = listener.incoming().for_each(move |(socket, _)| {
         // let socket = io_dump::Dump::to_stdout(socket);
 
-        let connection = Server::handshake(socket)
+        let connection = Connection::handshake(socket)
             .and_then(|conn| {
                 println!("H2 connection bound");
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,7 +5,7 @@ extern crate h2;
 extern crate http;
 extern crate tokio_core;
 
-use h2::server::Connection;
+use h2::server;
 
 use bytes::*;
 use futures::*;
@@ -27,7 +27,7 @@ pub fn main() {
     let server = listener.incoming().for_each(move |(socket, _)| {
         // let socket = io_dump::Dump::to_stdout(socket);
 
-        let connection = Connection::handshake(socket)
+        let connection = server::handshake(socket)
             .and_then(|conn| {
                 println!("H2 connection bound");
 

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -13,7 +13,7 @@ fn handshake() {
         .write(SETTINGS_ACK)
         .build();
 
-    let (_, h2) = Client::handshake(mock).wait().unwrap();
+    let (h2, _) = client::Connection::handshake(mock).wait().unwrap();
 
     trace!("hands have been shook");
 
@@ -37,9 +37,9 @@ fn client_other_thread() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             ::std::thread::spawn(move || {
                 let request = Request::builder()
                     .uri("https://http2.akamai.com/")
@@ -76,7 +76,7 @@ fn recv_invalid_server_stream_id() {
         .write(&[0, 0, 8, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
         .build();
 
-    let (mut client, h2) = Client::handshake(mock).wait().unwrap();
+    let (h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -100,11 +100,11 @@ fn request_stream_id_overflows() {
     let (io, srv) = mock::new();
 
 
-    let h2 = Client::builder()
+    let h2 = client::Connection::builder()
         .initial_stream_id(::std::u32::MAX >> 1)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -172,13 +172,13 @@ fn client_builder_max_concurrent_streams() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let mut builder = Client::builder();
+    let mut builder = client::Connection::builder();
     builder.max_concurrent_streams(1);
 
     let h2 = builder
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -219,9 +219,9 @@ fn request_over_max_concurrent_streams_errors() {
         .send_frame(frames::data(5, "").eos())
         .close();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             // we send a simple req here just to drive the connection so we can
             // receive the server settings.
             let request = Request::builder()
@@ -294,9 +294,9 @@ fn http_11_request_without_scheme_or_authority() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             // we send a simple req here just to drive the connection so we can
             // receive the server settings.
             let request = Request::builder()
@@ -324,9 +324,9 @@ fn http_2_request_without_scheme_or_authority() {
         .recv_settings()
         .close();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             // we send a simple req here just to drive the connection so we can
             // receive the server settings.
             let request = Request::builder()
@@ -367,9 +367,9 @@ fn request_with_connection_headers() {
         ("te", "boom"),
     ];
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(move |(mut client, conn)| {
+        .and_then(move |(conn, mut client)| {
             for (name, val) in headers {
                 let req = Request::builder()
                     .uri("https://http2.akamai.com/")
@@ -402,9 +402,9 @@ fn connection_close_notifies_response_future() {
         // don't send any response, just close
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(())
@@ -444,9 +444,9 @@ fn connection_close_notifies_client_poll_ready() {
         )
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(())
@@ -497,9 +497,9 @@ fn sending_request_on_closed_connection() {
         .send_frame(frames::headers(0).response(200).eos())
         .close();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(())

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -13,7 +13,7 @@ fn handshake() {
         .write(SETTINGS_ACK)
         .build();
 
-    let (h2, _) = client::Connection::handshake(mock).wait().unwrap();
+    let (_, h2) = client::handshake(mock).wait().unwrap();
 
     trace!("hands have been shook");
 
@@ -37,9 +37,9 @@ fn client_other_thread() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             ::std::thread::spawn(move || {
                 let request = Request::builder()
                     .uri("https://http2.akamai.com/")
@@ -76,7 +76,7 @@ fn recv_invalid_server_stream_id() {
         .write(&[0, 0, 8, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
         .build();
 
-    let (h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, h2) = client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -100,11 +100,11 @@ fn request_stream_id_overflows() {
     let (io, srv) = mock::new();
 
 
-    let h2 = client::Connection::builder()
+    let h2 = client::Builder::new()
         .initial_stream_id(::std::u32::MAX >> 1)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -172,13 +172,13 @@ fn client_builder_max_concurrent_streams() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let mut builder = client::Connection::builder();
+    let mut builder = client::Builder::new();
     builder.max_concurrent_streams(1);
 
     let h2 = builder
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -219,9 +219,9 @@ fn request_over_max_concurrent_streams_errors() {
         .send_frame(frames::data(5, "").eos())
         .close();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             // we send a simple req here just to drive the connection so we can
             // receive the server settings.
             let request = Request::builder()
@@ -294,9 +294,9 @@ fn http_11_request_without_scheme_or_authority() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             // we send a simple req here just to drive the connection so we can
             // receive the server settings.
             let request = Request::builder()
@@ -324,9 +324,9 @@ fn http_2_request_without_scheme_or_authority() {
         .recv_settings()
         .close();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             // we send a simple req here just to drive the connection so we can
             // receive the server settings.
             let request = Request::builder()
@@ -367,9 +367,9 @@ fn request_with_connection_headers() {
         ("te", "boom"),
     ];
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(move |(conn, mut client)| {
+        .and_then(move |(mut client, conn)| {
             for (name, val) in headers {
                 let req = Request::builder()
                     .uri("https://http2.akamai.com/")
@@ -402,9 +402,9 @@ fn connection_close_notifies_response_future() {
         // don't send any response, just close
         .close();
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(())
@@ -444,9 +444,9 @@ fn connection_close_notifies_client_poll_ready() {
         )
         .close();
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(())
@@ -497,9 +497,9 @@ fn sending_request_on_closed_connection() {
         .send_frame(frames::headers(0).response(200).eos())
         .close();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(())

--- a/tests/codec_write.rs
+++ b/tests/codec_write.rs
@@ -27,9 +27,9 @@ fn write_continuation_frames() {
         )
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let mut request = Request::builder();
             request.uri("https://http2.akamai.com/");
 

--- a/tests/codec_write.rs
+++ b/tests/codec_write.rs
@@ -27,9 +27,9 @@ fn write_continuation_frames() {
         )
         .close();
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let mut request = Request::builder();
             request.uri("https://http2.akamai.com/");
 

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -27,7 +27,7 @@ fn send_data_without_requesting_capacity() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -82,7 +82,7 @@ fn release_capacity_sends_window_update() {
         // gotta end the connection
         .map(drop);
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -147,7 +147,7 @@ fn release_capacity_of_small_amount_does_not_send_window_update() {
         // gotta end the connection
         .map(drop);
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -216,7 +216,7 @@ fn recv_data_overflows_connection_window() {
         .recv_frame(frames::go_away(0).flow_control());
     // connection is ended by client
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -279,11 +279,11 @@ fn recv_data_overflows_stream_window() {
         .recv_frame(frames::reset(1).flow_control())
         .close();
 
-    let h2 = Client::builder()
+    let h2 = client::Connection::builder()
         .initial_window_size(16_384)
         .handshake::<_, Bytes>(io)
         .unwrap()
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://http2.akamai.com/")
@@ -348,8 +348,8 @@ fn stream_error_release_connection_capacity() {
         .recv_frame(frames::window_update(0, 16_384 * 2 + 10))
         .close();
 
-    let client = Client::handshake(io).unwrap()
-        .and_then(|(mut client, conn)| {
+    let client = client::Connection::handshake(io).unwrap()
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(()).unwrap();
@@ -397,7 +397,7 @@ fn stream_close_by_data_frame_releases_capacity() {
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::POST)
             .uri("https://http2.akamai.com/")
@@ -468,7 +468,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::POST)
             .uri("https://http2.akamai.com/")
@@ -551,9 +551,9 @@ fn recv_window_update_on_stream_closed_by_data_frame() {
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .unwrap()
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -600,9 +600,9 @@ fn reserved_capacity_assigned_in_multi_window_updates() {
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .unwrap()
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -729,7 +729,7 @@ fn connection_notified_on_released_capacity() {
 
 
     let th2 = thread::spawn(move || {
-        let (mut client, h2) = Client::handshake(io).wait().unwrap();
+        let (h2, mut client) = client::Connection::handshake(io).wait().unwrap();
 
         let (h2, _) = h2.drive(settings_rx).wait().unwrap();
 
@@ -809,8 +809,8 @@ fn recv_settings_removes_available_capacity() {
         .close();
 
 
-    let h2 = Client::handshake(io).unwrap()
-        .and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap()
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -870,8 +870,8 @@ fn recv_no_init_window_then_receive_some_init_window() {
         .close();
 
 
-    let h2 = Client::handshake(io).unwrap()
-        .and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap()
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -971,7 +971,7 @@ fn settings_lowered_capacity_returns_capacity_to_connection() {
             .wait().unwrap();
     });
 
-    let (mut client, h2) = Client::handshake(io).unwrap()
+    let (h2, mut client) = client::Connection::handshake(io).unwrap()
         .wait().unwrap();
 
     // Drive client connection
@@ -1034,8 +1034,8 @@ fn client_increase_target_window_size() {
         .close();
 
 
-    let client = Client::handshake(io).unwrap()
-        .and_then(|(_client, mut conn)| {
+    let client = client::Connection::handshake(io).unwrap()
+        .and_then(|(mut conn, _client)| {
             conn.set_target_window_size(2 << 20);
 
             conn.unwrap()
@@ -1062,8 +1062,8 @@ fn increase_target_window_size_after_using_some() {
         .recv_frame(frames::window_update(0, (2 << 20) - 65_535))
         .close();
 
-    let client = Client::handshake(io).unwrap()
-        .and_then(|(mut client, conn)| {
+    let client = client::Connection::handshake(io).unwrap()
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(()).unwrap();
@@ -1105,8 +1105,8 @@ fn decrease_target_window_size() {
         .recv_frame(frames::window_update(0, 16_384))
         .close();
 
-    let client = Client::handshake(io).unwrap()
-        .and_then(|(mut client, mut conn)| {
+    let client = client::Connection::handshake(io).unwrap()
+        .and_then(|(mut conn, mut client)| {
             conn.set_target_window_size(16_384 * 2);
 
             let request = Request::builder()

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -27,7 +27,7 @@ fn send_data_without_requesting_capacity() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -82,7 +82,7 @@ fn release_capacity_sends_window_update() {
         // gotta end the connection
         .map(drop);
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -147,7 +147,7 @@ fn release_capacity_of_small_amount_does_not_send_window_update() {
         // gotta end the connection
         .map(drop);
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -216,7 +216,7 @@ fn recv_data_overflows_connection_window() {
         .recv_frame(frames::go_away(0).flow_control());
     // connection is ended by client
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -279,11 +279,11 @@ fn recv_data_overflows_stream_window() {
         .recv_frame(frames::reset(1).flow_control())
         .close();
 
-    let h2 = client::Connection::builder()
+    let h2 = client::Builder::new()
         .initial_window_size(16_384)
         .handshake::<_, Bytes>(io)
         .unwrap()
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://http2.akamai.com/")
@@ -348,8 +348,8 @@ fn stream_error_release_connection_capacity() {
         .recv_frame(frames::window_update(0, 16_384 * 2 + 10))
         .close();
 
-    let client = client::Connection::handshake(io).unwrap()
-        .and_then(|(conn, mut client)| {
+    let client = client::handshake(io).unwrap()
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(()).unwrap();
@@ -397,7 +397,7 @@ fn stream_close_by_data_frame_releases_capacity() {
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::POST)
             .uri("https://http2.akamai.com/")
@@ -468,7 +468,7 @@ fn stream_close_by_trailers_frame_releases_capacity() {
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::POST)
             .uri("https://http2.akamai.com/")
@@ -551,9 +551,9 @@ fn recv_window_update_on_stream_closed_by_data_frame() {
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .unwrap()
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -600,9 +600,9 @@ fn reserved_capacity_assigned_in_multi_window_updates() {
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .unwrap()
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -729,7 +729,7 @@ fn connection_notified_on_released_capacity() {
 
 
     let th2 = thread::spawn(move || {
-        let (h2, mut client) = client::Connection::handshake(io).wait().unwrap();
+        let (mut client, h2) = client::handshake(io).wait().unwrap();
 
         let (h2, _) = h2.drive(settings_rx).wait().unwrap();
 
@@ -809,8 +809,8 @@ fn recv_settings_removes_available_capacity() {
         .close();
 
 
-    let h2 = client::Connection::handshake(io).unwrap()
-        .and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap()
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -870,8 +870,8 @@ fn recv_no_init_window_then_receive_some_init_window() {
         .close();
 
 
-    let h2 = client::Connection::handshake(io).unwrap()
-        .and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap()
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")
@@ -971,7 +971,7 @@ fn settings_lowered_capacity_returns_capacity_to_connection() {
             .wait().unwrap();
     });
 
-    let (h2, mut client) = client::Connection::handshake(io).unwrap()
+    let (mut client, h2) = client::handshake(io).unwrap()
         .wait().unwrap();
 
     // Drive client connection
@@ -1034,8 +1034,8 @@ fn client_increase_target_window_size() {
         .close();
 
 
-    let client = client::Connection::handshake(io).unwrap()
-        .and_then(|(mut conn, _client)| {
+    let client = client::handshake(io).unwrap()
+        .and_then(|(_client, mut conn)| {
             conn.set_target_window_size(2 << 20);
 
             conn.unwrap()
@@ -1062,8 +1062,8 @@ fn increase_target_window_size_after_using_some() {
         .recv_frame(frames::window_update(0, (2 << 20) - 65_535))
         .close();
 
-    let client = client::Connection::handshake(io).unwrap()
-        .and_then(|(conn, mut client)| {
+    let client = client::handshake(io).unwrap()
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .uri("https://http2.akamai.com/")
                 .body(()).unwrap();
@@ -1105,8 +1105,8 @@ fn decrease_target_window_size() {
         .recv_frame(frames::window_update(0, 16_384))
         .close();
 
-    let client = client::Connection::handshake(io).unwrap()
-        .and_then(|(mut conn, mut client)| {
+    let client = client::handshake(io).unwrap()
+        .and_then(|(mut client, mut conn)| {
             conn.set_target_window_size(16_384 * 2);
 
             let request = Request::builder()
@@ -1180,8 +1180,8 @@ fn recv_settings_increase_window_size_after_using_some() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let client = client::Connection::handshake(io).unwrap()
-        .and_then(|(conn, mut client)| {
+    let client = client::handshake(io).unwrap()
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method("POST")
                 .uri("https://http2.akamai.com/")

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -1142,7 +1142,7 @@ fn server_target_window_size() {
         .recv_frame(frames::window_update(0, (2 << 20) - 65_535))
         .close();
 
-    let srv = Server::handshake(io).unwrap()
+    let srv = server::Connection::handshake(io).unwrap()
         .and_then(|mut conn| {
             conn.set_target_window_size(2 << 20);
             conn.into_future().unwrap()

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -1142,7 +1142,7 @@ fn server_target_window_size() {
         .recv_frame(frames::window_update(0, (2 << 20) - 65_535))
         .close();
 
-    let srv = server::Connection::handshake(io).unwrap()
+    let srv = server::handshake(io).unwrap()
         .and_then(|mut conn| {
             conn.set_target_window_size(2 << 20);
             conn.into_future().unwrap()
@@ -1180,8 +1180,8 @@ fn recv_settings_increase_window_size_after_using_some() {
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let client = Client::handshake(io).unwrap()
-        .and_then(|(mut client, conn)| {
+    let client = client::Connection::handshake(io).unwrap()
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method("POST")
                 .uri("https://http2.akamai.com/")

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -49,7 +49,7 @@ fn recv_multiple_pings() {
         .recv_frame(frames::ping([2; 8]).pong())
         .close();
 
-    let srv = server::Connection::handshake(io)
+    let srv = server::handshake(io)
         .expect("handshake")
         .and_then(|srv| {
             // future of first request, which never comes
@@ -79,7 +79,7 @@ fn pong_has_highest_priority() {
         .recv_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let srv = server::Connection::handshake(io)
+    let srv = server::handshake(io)
         .expect("handshake")
         .and_then(|srv| {
             // future of first request

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -49,7 +49,7 @@ fn recv_multiple_pings() {
         .recv_frame(frames::ping([2; 8]).pong())
         .close();
 
-    let srv = Server::handshake(io)
+    let srv = server::Connection::handshake(io)
         .expect("handshake")
         .and_then(|srv| {
             // future of first request, which never comes
@@ -79,7 +79,7 @@ fn pong_has_highest_priority() {
         .recv_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let srv = Server::handshake(io)
+    let srv = server::Connection::handshake(io)
         .expect("handshake")
         .and_then(|srv| {
             // future of first request

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -8,9 +8,9 @@ fn recv_single_ping() {
     let (m, mock) = mock::new();
 
     // Create the handshake
-    let h2 = Client::handshake(m)
+    let h2 = client::Connection::handshake(m)
         .unwrap()
-        .and_then(|(_, conn)| conn.unwrap());
+        .and_then(|(conn, _)| conn.unwrap());
 
     let mock = mock.assert_client_handshake()
         .unwrap()

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -8,9 +8,9 @@ fn recv_single_ping() {
     let (m, mock) = mock::new();
 
     // Create the handshake
-    let h2 = client::Connection::handshake(m)
+    let h2 = client::handshake(m)
         .unwrap()
-        .and_then(|(conn, _)| conn.unwrap());
+        .and_then(|(_, conn)| conn.unwrap());
 
     let mock = mock.assert_client_handshake()
         .unwrap()

--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -26,7 +26,7 @@ fn single_stream_send_large_body() {
         .build();
 
     let notify = MockNotify::new();
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Poll h2 once to get notifications
     loop {
@@ -94,7 +94,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
         .build();
 
     let notify = MockNotify::new();
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Poll h2 once to get notifications
     loop {
@@ -181,7 +181,7 @@ fn single_stream_send_body_greater_than_default_window() {
         .build();
 
     let notify = MockNotify::new();
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Poll h2 once to get notifications
     loop {
@@ -265,7 +265,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -296,9 +296,9 @@ fn send_data_receive_window_update() {
     let _ = ::env_logger::init();
     let (m, mock) = mock::new();
 
-    let h2 = Client::handshake(m)
+    let h2 = client::Connection::handshake(m)
         .unwrap()
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")

--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -26,7 +26,7 @@ fn single_stream_send_large_body() {
         .build();
 
     let notify = MockNotify::new();
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Poll h2 once to get notifications
     loop {
@@ -94,7 +94,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
         .build();
 
     let notify = MockNotify::new();
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Poll h2 once to get notifications
     loop {
@@ -181,7 +181,7 @@ fn single_stream_send_body_greater_than_default_window() {
         .build();
 
     let notify = MockNotify::new();
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Poll h2 once to get notifications
     loop {
@@ -265,7 +265,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -296,9 +296,9 @@ fn send_data_receive_window_update() {
     let _ = ::env_logger::init();
     let (m, mock) = mock::new();
 
-    let h2 = client::Connection::handshake(m)
+    let h2 = client::handshake(m)
         .unwrap()
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::POST)
                 .uri("https://http2.akamai.com/")

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -20,7 +20,7 @@ fn recv_push_works() {
         .send_frame(frames::headers(1).response(200).eos())
         .send_frame(frames::headers(2).response(200).eos());
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -58,11 +58,11 @@ fn recv_push_when_push_disabled_is_conn_error() {
         .send_frame(frames::headers(1).response(200).eos())
         .recv_frame(frames::go_away(0).protocol_error());
 
-    let h2 = Client::builder()
+    let h2 = client::Connection::builder()
         .enable_push(false)
         .handshake::<_, Bytes>(io)
         .unwrap()
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://http2.akamai.com/")
@@ -115,7 +115,7 @@ fn pending_push_promises_reset_when_dropped() {
         .recv_frame(frames::reset(2).cancel())
         .close();
 
-    let client = Client::handshake(io).unwrap().and_then(|(mut client, conn)| {
+    let client = client::Connection::handshake(io).unwrap().and_then(|(conn, mut client)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -20,7 +20,7 @@ fn recv_push_works() {
         .send_frame(frames::headers(1).response(200).eos())
         .send_frame(frames::headers(2).response(200).eos());
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")
@@ -58,11 +58,11 @@ fn recv_push_when_push_disabled_is_conn_error() {
         .send_frame(frames::headers(1).response(200).eos())
         .recv_frame(frames::go_away(0).protocol_error());
 
-    let h2 = client::Connection::builder()
+    let h2 = client::Builder::new()
         .enable_push(false)
         .handshake::<_, Bytes>(io)
         .unwrap()
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://http2.akamai.com/")
@@ -115,7 +115,7 @@ fn pending_push_promises_reset_when_dropped() {
         .recv_frame(frames::reset(2).cancel())
         .close();
 
-    let client = client::Connection::handshake(io).unwrap().and_then(|(conn, mut client)| {
+    let client = client::handshake(io).unwrap().and_then(|(mut client, conn)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://http2.akamai.com/")

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -17,7 +17,7 @@ fn read_preface_in_multiple_frames() {
         .read(SETTINGS_ACK)
         .build();
 
-    let h2 = Server::handshake(mock).wait().unwrap();
+    let h2 = server::Connection::handshake(mock).wait().unwrap();
 
     assert!(Stream::wait(h2).next().is_none());
 }
@@ -47,7 +47,7 @@ fn server_builder_set_max_concurrent_streams() {
         .recv_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let mut builder = Server::builder();
+    let mut builder = server::Connection::builder();
     builder.max_concurrent_streams(1);
 
     let h2 = builder
@@ -89,7 +89,7 @@ fn serve_request() {
         .recv_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let srv = Server::handshake(io).expect("handshake").and_then(|srv| {
+    let srv = server::Connection::handshake(io).expect("handshake").and_then(|srv| {
         srv.into_future().unwrap().and_then(|(reqstream, srv)| {
             let (req, mut stream) = reqstream.unwrap();
 
@@ -129,7 +129,7 @@ fn recv_invalid_authority() {
         .recv_frame(frames::reset(1).protocol_error())
         .close();
 
-    let srv = Server::handshake(io)
+    let srv = server::Connection::handshake(io)
         .expect("handshake")
         .and_then(|srv| srv.into_future().unwrap());
 
@@ -164,7 +164,7 @@ fn recv_connection_header() {
         .recv_frame(frames::reset(9).protocol_error())
         .close();
 
-    let srv = Server::handshake(io)
+    let srv = server::Connection::handshake(io)
         .expect("handshake")
         .and_then(|srv| srv.into_future().unwrap());
 
@@ -188,7 +188,7 @@ fn sends_reset_cancel_when_body_is_dropped() {
         .recv_frame(frames::reset(1).cancel())
         .close();
 
-    let srv = Server::handshake(io).expect("handshake").and_then(|srv| {
+    let srv = server::Connection::handshake(io).expect("handshake").and_then(|srv| {
         srv.into_future().unwrap().and_then(|(reqstream, srv)| {
             let (req, mut stream) = reqstream.unwrap();
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -17,7 +17,7 @@ fn read_preface_in_multiple_frames() {
         .read(SETTINGS_ACK)
         .build();
 
-    let h2 = server::Connection::handshake(mock).wait().unwrap();
+    let h2 = server::handshake(mock).wait().unwrap();
 
     assert!(Stream::wait(h2).next().is_none());
 }
@@ -47,7 +47,7 @@ fn server_builder_set_max_concurrent_streams() {
         .recv_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let mut builder = server::Connection::builder();
+    let mut builder = server::Builder::new();
     builder.max_concurrent_streams(1);
 
     let h2 = builder
@@ -89,7 +89,7 @@ fn serve_request() {
         .recv_frame(frames::headers(1).response(200).eos())
         .close();
 
-    let srv = server::Connection::handshake(io).expect("handshake").and_then(|srv| {
+    let srv = server::handshake(io).expect("handshake").and_then(|srv| {
         srv.into_future().unwrap().and_then(|(reqstream, srv)| {
             let (req, mut stream) = reqstream.unwrap();
 
@@ -129,7 +129,7 @@ fn recv_invalid_authority() {
         .recv_frame(frames::reset(1).protocol_error())
         .close();
 
-    let srv = server::Connection::handshake(io)
+    let srv = server::handshake(io)
         .expect("handshake")
         .and_then(|srv| srv.into_future().unwrap());
 
@@ -164,7 +164,7 @@ fn recv_connection_header() {
         .recv_frame(frames::reset(9).protocol_error())
         .close();
 
-    let srv = server::Connection::handshake(io)
+    let srv = server::handshake(io)
         .expect("handshake")
         .and_then(|srv| srv.into_future().unwrap());
 
@@ -188,7 +188,7 @@ fn sends_reset_cancel_when_body_is_dropped() {
         .recv_frame(frames::reset(1).cancel())
         .close();
 
-    let srv = server::Connection::handshake(io).expect("handshake").and_then(|srv| {
+    let srv = server::handshake(io).expect("handshake").and_then(|srv| {
         srv.into_future().unwrap().and_then(|(reqstream, srv)| {
             let (req, mut stream) = reqstream.unwrap();
 

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -20,7 +20,7 @@ fn send_recv_headers_only() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -62,7 +62,7 @@ fn send_recv_data() {
         ])
         .build();
 
-    let (mut h2, mut client) = client::Connection::builder().handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::Builder::new().handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -119,7 +119,7 @@ fn send_headers_recv_data_single_frame() {
         ])
         .build();
 
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -154,7 +154,7 @@ fn closed_streams_are_released() {
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::get("https://example.com/").body(()).unwrap();
 
         // Send request
@@ -199,7 +199,7 @@ fn errors_if_recv_frame_exceeds_max_frame_size() {
     let _ = ::env_logger::init();
     let (io, mut srv) = mock::new();
 
-    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
+    let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://example.com/")
@@ -254,11 +254,11 @@ fn configure_max_frame_size() {
     let _ = ::env_logger::init();
     let (io, mut srv) = mock::new();
 
-    let h2 = client::Connection::builder()
+    let h2 = client::Builder::new()
         .max_frame_size(16_384 * 2)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -325,9 +325,9 @@ fn recv_goaway_finishes_processed_streams() {
         .recv_frame(frames::go_away(0));
         //.close();
 
-    let h2 = client::Connection::handshake(io)
+    let h2 = client::handshake(io)
         .expect("handshake")
-        .and_then(|(h2, mut client)| {
+        .and_then(|(mut client, h2)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -429,11 +429,11 @@ fn skipped_stream_ids_are_implicitly_closed() {
         // implicitly closed.
         .send_frame(frames::headers(3).response(200));
 
-        let h2 = client::Connection::builder()
+        let h2 = client::Builder::new()
             .initial_stream_id(5)
             .handshake::<_, Bytes>(io)
             .expect("handshake")
-            .and_then(|(h2, mut client)| {
+            .and_then(|(mut client, h2)| {
                 let request = Request::builder()
                     .method(Method::GET)
                     .uri("https://example.com/")
@@ -491,9 +491,9 @@ fn send_rst_stream_allows_recv_data() {
         .ping_pong([1; 8])
         .close();
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -540,9 +540,9 @@ fn send_rst_stream_allows_recv_trailers() {
         .ping_pong([1; 8])
         .close();
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -591,11 +591,11 @@ fn rst_stream_expires() {
         .recv_frame(frames::go_away(0).protocol_error())
         .close();
 
-    let client = client::Connection::builder()
+    let client = client::Builder::new()
         .reset_stream_duration(Duration::from_millis(10))
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -663,11 +663,11 @@ fn rst_stream_max() {
         .recv_frame(frames::go_away(0).protocol_error())
         .close();
 
-    let client = client::Connection::builder()
+    let client = client::Builder::new()
         .max_concurrent_reset_streams(1)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -744,9 +744,9 @@ fn reserved_state_recv_window_update() {
         .ping_pong([1; 8])
         .close();
 
-    let client = client::Connection::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
-        .and_then(|(conn, mut client)| {
+        .and_then(|(mut client, conn)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -396,7 +396,7 @@ fn recv_next_stream_id_updated_by_malformed_headers() {
         .recv_frame(frames::go_away(1).protocol_error())
         .close();
 
-        let srv = server::Connection::handshake(io)
+        let srv = server::handshake(io)
             .expect("handshake")
             .and_then(|srv| srv.into_future().then(|res| {
                 let (err, _) = res.unwrap_err();

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -396,7 +396,7 @@ fn recv_next_stream_id_updated_by_malformed_headers() {
         .recv_frame(frames::go_away(1).protocol_error())
         .close();
 
-        let srv = Server::handshake(io)
+        let srv = server::Connection::handshake(io)
             .expect("handshake")
             .and_then(|srv| srv.into_future().then(|res| {
                 let (err, _) = res.unwrap_err();

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -20,7 +20,7 @@ fn send_recv_headers_only() {
         .read(&[0, 0, 1, 1, 5, 0, 0, 0, 1, 0x89])
         .build();
 
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -62,7 +62,7 @@ fn send_recv_data() {
         ])
         .build();
 
-    let (mut client, mut h2) = Client::builder().handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::builder().handshake(mock).wait().unwrap();
 
     let request = Request::builder()
         .method(Method::POST)
@@ -119,7 +119,7 @@ fn send_headers_recv_data_single_frame() {
         ])
         .build();
 
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -154,7 +154,7 @@ fn closed_streams_are_released() {
     let _ = ::env_logger::init();
     let (io, srv) = mock::new();
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::get("https://example.com/").body(()).unwrap();
 
         // Send request
@@ -199,7 +199,7 @@ fn errors_if_recv_frame_exceeds_max_frame_size() {
     let _ = ::env_logger::init();
     let (io, mut srv) = mock::new();
 
-    let h2 = Client::handshake(io).unwrap().and_then(|(mut client, h2)| {
+    let h2 = client::Connection::handshake(io).unwrap().and_then(|(h2, mut client)| {
         let request = Request::builder()
             .method(Method::GET)
             .uri("https://example.com/")
@@ -254,11 +254,11 @@ fn configure_max_frame_size() {
     let _ = ::env_logger::init();
     let (io, mut srv) = mock::new();
 
-    let h2 = Client::builder()
+    let h2 = client::Connection::builder()
         .max_frame_size(16_384 * 2)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -325,9 +325,9 @@ fn recv_goaway_finishes_processed_streams() {
         .recv_frame(frames::go_away(0));
         //.close();
 
-    let h2 = Client::handshake(io)
+    let h2 = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, h2)| {
+        .and_then(|(h2, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -429,11 +429,11 @@ fn skipped_stream_ids_are_implicitly_closed() {
         // implicitly closed.
         .send_frame(frames::headers(3).response(200));
 
-        let h2 = Client::builder()
+        let h2 = client::Connection::builder()
             .initial_stream_id(5)
             .handshake::<_, Bytes>(io)
             .expect("handshake")
-            .and_then(|(mut client, h2)| {
+            .and_then(|(h2, mut client)| {
                 let request = Request::builder()
                     .method(Method::GET)
                     .uri("https://example.com/")
@@ -491,9 +491,9 @@ fn send_rst_stream_allows_recv_data() {
         .ping_pong([1; 8])
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -540,9 +540,9 @@ fn send_rst_stream_allows_recv_trailers() {
         .ping_pong([1; 8])
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -591,11 +591,11 @@ fn rst_stream_expires() {
         .recv_frame(frames::go_away(0).protocol_error())
         .close();
 
-    let client = Client::builder()
+    let client = client::Connection::builder()
         .reset_stream_duration(Duration::from_millis(10))
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -663,11 +663,11 @@ fn rst_stream_max() {
         .recv_frame(frames::go_away(0).protocol_error())
         .close();
 
-    let client = Client::builder()
+    let client = client::Connection::builder()
         .max_concurrent_reset_streams(1)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")
@@ -744,9 +744,9 @@ fn reserved_state_recv_window_update() {
         .ping_pong([1; 8])
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::Connection::handshake(io)
         .expect("handshake")
-        .and_then(|(mut client, conn)| {
+        .and_then(|(conn, mut client)| {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri("https://example.com/")

--- a/tests/support/prelude.rs
+++ b/tests/support/prelude.rs
@@ -5,7 +5,7 @@ pub use super::h2;
 pub use self::h2::*;
 pub use self::h2::client::{self, Client};
 pub use self::h2::frame::StreamId;
-pub use self::h2::server::{self, Server};
+pub use self::h2::server;
 
 // Re-export mock
 pub use super::mock::{self, HandleFutureExt};

--- a/tests/support/prelude.rs
+++ b/tests/support/prelude.rs
@@ -3,7 +3,7 @@
 pub use super::h2;
 
 pub use self::h2::*;
-pub use self::h2::client::{self, Client};
+pub use self::h2::client;
 pub use self::h2::frame::StreamId;
 pub use self::h2::server;
 

--- a/tests/trailers.rs
+++ b/tests/trailers.rs
@@ -23,7 +23,7 @@ fn recv_trailers_only() {
         ])
         .build();
 
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -71,7 +71,7 @@ fn send_trailers_immediately() {
         ])
         .build();
 
-    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
+    let (mut client, mut h2) = client::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()

--- a/tests/trailers.rs
+++ b/tests/trailers.rs
@@ -23,7 +23,7 @@ fn recv_trailers_only() {
         ])
         .build();
 
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()
@@ -71,7 +71,7 @@ fn send_trailers_immediately() {
         ])
         .build();
 
-    let (mut client, mut h2) = Client::handshake(mock).wait().unwrap();
+    let (mut h2, mut client) = client::Connection::handshake(mock).wait().unwrap();
 
     // Send the request
     let request = Request::builder()


### PR DESCRIPTION
Misc renames to try to increase consistency across `client` and `server` modules.

* `server::Server` -> `server::Connection`.
* `client::Client` -> `client::SendRequest` (there already is a `client::Connection`).
* `server::Respond` -> `server::SendResponse`.

This also moves the `builder` and `handshake` fns from `client::Client` -> `client::Connection` as well as change the type orders in the tuple returned by the `server::Handshake` future.

Fixes #154