### PR TITLE
Remove invalid brackets

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -113,7 +113,7 @@
 //! }
 //! ```
 //!
-//! [prior knowledge]: (http://httpwg.org/specs/rfc7540.html#known-http)
+//! [prior knowledge]: http://httpwg.org/specs/rfc7540.html#known-http
 //! [`Server::handshake`]: struct.Server.html#method.handshake
 //! [HTTP/2.0 handshake]: http://httpwg.org/specs/rfc7540.html#ConnectionHeader
 //! [`Builder`]: struct.Builder.html


### PR DESCRIPTION
This patch makes a tiny change to remove invalid brackets in the
comment for server module example.

Due to invalid brackets, current crate docs jumps to invalid URL from
the link of `prior knowledge`.
https://carllerche.github.io/h2/h2/server/index.html#example