### PR TITLE
Add protocol version to response for client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -479,6 +479,8 @@ impl proto::Peer for Peer {
         let stream_id = headers.stream_id();
         let (pseudo, fields) = headers.into_parts();
 
+        b.version(Version::HTTP_2);
+
         if let Some(status) = pseudo.status {
             b.status(status);
         }


### PR DESCRIPTION
Since `convert_poll_message()` does not set protocol version as
HTTP/2.0, responses client received always display `version:
HTTP/1.1`. 
This patch adds `HTTP/2.0` to the response.

Fixes https://github.com/carllerche/h2/issues/204