### PR TITLE
SETTINGS_MAX_HEADER_LIST_SIZE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ unstable = []
 
 [dependencies]
 futures = "0.1"
-tokio-io = "0.1.3"
+tokio-io = "0.1.4"
 bytes = "0.4"
 http = "0.1"
 byteorder = "1.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -172,6 +172,12 @@ impl Builder {
         self
     }
 
+    /// Set the max size of received header frames.
+    pub fn max_header_list_size(&mut self, max: u32) -> &mut Self {
+        self.settings.set_max_header_list_size(Some(max));
+        self
+    }
+
     /// Set the maximum number of concurrent streams.
     ///
     /// Clients can only limit the maximum number of streams that that the
@@ -337,6 +343,10 @@ where
 
         if let Some(max) = self.builder.settings.max_frame_size() {
             codec.set_max_recv_frame_size(max as usize);
+        }
+
+        if let Some(max) = self.builder.settings.max_header_list_size() {
+            codec.set_max_recv_header_list_size(max as usize);
         }
 
         // Send initial settings frame

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -54,6 +54,15 @@ pub enum UserError {
 
 // ===== impl RecvError =====
 
+impl RecvError {
+    pub(crate) fn is_stream_error(&self) -> bool {
+        match *self {
+            RecvError::Stream { .. } => true,
+            _ => false,
+        }
+    }
+}
+
 impl From<io::Error> for RecvError {
     fn from(src: io::Error) -> Self {
         RecvError::Io(src)

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -90,6 +90,11 @@ impl<T, B> Codec<T, B> {
         self.framed_write().set_max_frame_size(val)
     }
 
+    /// Set the max header list size that can be received.
+    pub fn set_max_recv_header_list_size(&mut self, val: usize) {
+        self.inner.set_max_header_list_size(val);
+    }
+
     /// Get a reference to the inner stream.
     #[cfg(feature = "unstable")]
     pub fn get_ref(&self) -> &T {

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -722,6 +722,7 @@ impl HeaderBlock {
         }
 
         let mut cursor = Cursor::new(src);
+        info!("hpack pre-load; cursor pos={}, len={}", cursor.position(), cursor.get_ref().len());
 
         // If the header frame is malformed, we still have to continue decoding
         // the headers. A malformed header frame is a stream level error, but
@@ -768,6 +769,8 @@ impl HeaderBlock {
                 Status(v) => set_pseudo!(status, v),
             }
         });
+
+        info!("hpack load; cursor pos={}, len={}", cursor.position(), cursor.get_ref().len());
 
         if let Err(e) = res {
             trace!("hpack decoding error; err={:?}", e);

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -696,7 +696,7 @@ impl fmt::Debug for PushPromiseFlag {
 
 impl HeaderBlock {
     fn load(&mut self, src: &mut BytesMut, max_header_list_size: usize, decoder: &mut hpack::Decoder) -> Result<(), Error> {
-        let mut reg = false;
+        let mut reg = !self.fields.is_empty();
         let mut malformed = false;
         let mut headers_size = self.calculate_header_list_size();
 

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -722,7 +722,6 @@ impl HeaderBlock {
         }
 
         let mut cursor = Cursor::new(src);
-        info!("hpack pre-load; cursor pos={}, len={}", cursor.position(), cursor.get_ref().len());
 
         // If the header frame is malformed, we still have to continue decoding
         // the headers. A malformed header frame is a stream level error, but
@@ -769,8 +768,6 @@ impl HeaderBlock {
                 Status(v) => set_pseudo!(status, v),
             }
         });
-
-        info!("hpack load; cursor pos={}, len={}", cursor.position(), cursor.get_ref().len());
 
         if let Err(e) = res {
             trace!("hpack decoding error; err={:?}", e);

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -323,8 +323,8 @@ impl PushPromise {
         Ok((frame, src))
     }
 
-    pub fn load_hpack(&mut self, src: &mut BytesMut, decoder: &mut hpack::Decoder) -> Result<(), Error> {
-        self.header_block.load(src, 0, decoder)
+    pub fn load_hpack(&mut self, src: &mut BytesMut, max_header_list_size: usize, decoder: &mut hpack::Decoder) -> Result<(), Error> {
+        self.header_block.load(src, max_header_list_size, decoder)
     }
 
     pub fn stream_id(&self) -> StreamId {

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -86,6 +86,9 @@ struct HeaderBlock {
     /// The decoded header fields
     fields: HeaderMap,
 
+    /// Set to true if decoding went over the max header list size.
+    is_over_size: bool,
+
     /// Pseudo headers, these are broken out as they must be sent as part of the
     /// headers frame.
     pseudo: Pseudo,
@@ -116,6 +119,7 @@ impl Headers {
             stream_dep: None,
             header_block: HeaderBlock {
                 fields: fields,
+                is_over_size: false,
                 pseudo: pseudo,
             },
             flags: HeadersFlag::default(),
@@ -131,6 +135,7 @@ impl Headers {
             stream_dep: None,
             header_block: HeaderBlock {
                 fields: fields,
+                is_over_size: false,
                 pseudo: Pseudo::default(),
             },
             flags: flags,
@@ -185,6 +190,7 @@ impl Headers {
             stream_dep: stream_dep,
             header_block: HeaderBlock {
                 fields: HeaderMap::new(),
+                is_over_size: false,
                 pseudo: Pseudo::default(),
             },
             flags: flags,
@@ -193,8 +199,8 @@ impl Headers {
         Ok((headers, src))
     }
 
-    pub fn load_hpack(&mut self, src: BytesMut, decoder: &mut hpack::Decoder) -> Result<(), Error> {
-        self.header_block.load(src, decoder)
+    pub fn load_hpack(&mut self, src: &mut BytesMut, max_header_list_size: usize, decoder: &mut hpack::Decoder) -> Result<(), Error> {
+        self.header_block.load(src, max_header_list_size, decoder)
     }
 
     pub fn stream_id(&self) -> StreamId {
@@ -215,6 +221,10 @@ impl Headers {
 
     pub fn set_end_stream(&mut self) {
         self.flags.set_end_stream()
+    }
+
+    pub fn is_over_size(&self) -> bool {
+        self.header_block.is_over_size
     }
 
     pub fn into_parts(self) -> (Pseudo, HeaderMap) {
@@ -304,6 +314,7 @@ impl PushPromise {
             flags: flags,
             header_block: HeaderBlock {
                 fields: HeaderMap::new(),
+                is_over_size: false,
                 pseudo: Pseudo::default(),
             },
             promised_id: promised_id,
@@ -312,8 +323,8 @@ impl PushPromise {
         Ok((frame, src))
     }
 
-    pub fn load_hpack(&mut self, src: BytesMut, decoder: &mut hpack::Decoder) -> Result<(), Error> {
-        self.header_block.load(src, decoder)
+    pub fn load_hpack(&mut self, src: &mut BytesMut, decoder: &mut hpack::Decoder) -> Result<(), Error> {
+        self.header_block.load(src, 0, decoder)
     }
 
     pub fn stream_id(&self) -> StreamId {
@@ -330,6 +341,10 @@ impl PushPromise {
 
     pub fn set_end_headers(&mut self) {
         self.flags.set_end_headers();
+    }
+
+    pub fn is_over_size(&self) -> bool {
+        self.header_block.is_over_size
     }
 
     pub fn encode(self, encoder: &mut hpack::Encoder, dst: &mut BytesMut) -> Option<Continuation> {
@@ -364,6 +379,7 @@ impl PushPromise {
             flags: PushPromiseFlag::default(),
             header_block: HeaderBlock {
                 fields,
+                is_over_size: false,
                 pseudo,
             },
             promised_id,
@@ -677,10 +693,12 @@ impl fmt::Debug for PushPromiseFlag {
 
 // ===== HeaderBlock =====
 
+
 impl HeaderBlock {
-    fn load(&mut self, src: BytesMut, decoder: &mut hpack::Decoder) -> Result<(), Error> {
+    fn load(&mut self, src: &mut BytesMut, max_header_list_size: usize, decoder: &mut hpack::Decoder) -> Result<(), Error> {
         let mut reg = false;
         let mut malformed = false;
+        let mut headers_size = self.calculate_header_list_size();
 
         macro_rules! set_pseudo {
             ($field:ident, $val:expr) => {{
@@ -691,22 +709,25 @@ impl HeaderBlock {
                     trace!("load_hpack; header malformed -- repeated pseudo");
                     malformed = true;
                 } else {
-                    self.pseudo.$field = Some($val);
+                    let __val = $val;
+                    headers_size += decoded_header_size(stringify!($ident).len() + 1, __val.as_str().len());
+                    if headers_size < max_header_list_size {
+                        self.pseudo.$field = Some(__val);
+                    } else if !self.is_over_size {
+                        trace!("load_hpack; header list size over max");
+                        self.is_over_size = true;
+                    }
                 }
             }}
         }
 
-        let mut src = Cursor::new(src.freeze());
+        let mut cursor = Cursor::new(src);
 
-        // At this point, we're going to assume that the hpack encoded headers
-        // contain the entire payload. Later, we need to check for stream
-        // priority.
-        //
         // If the header frame is malformed, we still have to continue decoding
         // the headers. A malformed header frame is a stream level error, but
         // the hpack state is connection level. In order to maintain correct
         // state for other streams, the hpack decoding process must complete.
-        let res = decoder.decode(&mut src, |header| {
+        let res = decoder.decode(&mut cursor, |header| {
             use hpack::Header::*;
 
             match header {
@@ -730,7 +751,14 @@ impl HeaderBlock {
                         malformed = true;
                     } else {
                         reg = true;
-                        self.fields.append(name, value);
+
+                        headers_size += decoded_header_size(name.as_str().len(), value.len());
+                        if headers_size < max_header_list_size {
+                            self.fields.append(name, value);
+                        } else if !self.is_over_size {
+                            trace!("load_hpack; header list size over max");
+                            self.is_over_size = true;
+                        }
                     }
                 },
                 Authority(v) => set_pseudo!(authority, v),
@@ -762,5 +790,49 @@ impl HeaderBlock {
                 fields: self.fields.into_iter(),
             },
         }
+    }
+
+    /// Calculates the size of the currently decoded header list.
+    ///
+    /// According to http://httpwg.org/specs/rfc7540.html#SETTINGS_MAX_HEADER_LIST_SIZE
+    ///
+    /// > The value is based on the uncompressed size of header fields,
+    /// > including the length of the name and value in octets plus an
+    /// > overhead of 32 octets for each header field.
+    fn calculate_header_list_size(&self) -> usize {
+        macro_rules! pseudo_size {
+            ($name:ident) => ({
+                self.pseudo
+                    .$name
+                    .as_ref()
+                    .map(|m| decoded_header_size(stringify!($name).len() + 1, m.as_str().len()))
+                    .unwrap_or(0)
+            });
+        }
+
+        pseudo_size!(method) +
+        pseudo_size!(scheme) +
+        pseudo_size!(status) +
+        pseudo_size!(authority) +
+        pseudo_size!(path) +
+        self.fields.iter()
+            .map(|(name, value)| decoded_header_size(name.as_str().len(), value.len()))
+            .sum::<usize>()
+    }
+}
+
+fn decoded_header_size(name: usize, value: usize) -> usize {
+    name + value + 32
+}
+
+// Stupid hack to make the set_pseudo! macro happy, since all other values
+// have a method `as_str` except for `String<Bytes>`.
+trait AsStr {
+    fn as_str(&self) -> &str;
+}
+
+impl AsStr for String<Bytes> {
+    fn as_str(&self) -> &str {
+        self
     }
 }

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -89,6 +89,14 @@ impl Settings {
         self.max_frame_size = size;
     }
 
+    pub fn max_header_list_size(&self) -> Option<u32> {
+        self.max_header_list_size
+    }
+
+    pub fn set_max_header_list_size(&mut self, size: Option<u32>) {
+        self.max_header_list_size = size;
+    }
+
     pub fn is_push_enabled(&self) -> bool {
         self.enable_push.unwrap_or(1) != 0
     }

--- a/src/hpack/mod.rs
+++ b/src/hpack/mod.rs
@@ -7,6 +7,6 @@ mod table;
 #[cfg(test)]
 mod test;
 
-pub use self::decoder::{Decoder, DecoderError};
+pub use self::decoder::{Decoder, DecoderError, NeedMore};
 pub use self::encoder::{Encode, EncodeState, Encoder, EncoderError};
 pub use self::header::Header;

--- a/src/hpack/test/fixture.rs
+++ b/src/hpack/test/fixture.rs
@@ -74,7 +74,7 @@ fn test_story(story: Value) {
             }
 
             decoder
-                .decode(&mut Cursor::new(case.wire.clone().into()), |e| {
+                .decode(&mut Cursor::new(&mut case.wire.clone().into()), |e| {
                     let (name, value) = expect.remove(0);
                     assert_eq!(name, key_str(&e));
                     assert_eq!(value, value_str(&e));
@@ -108,7 +108,7 @@ fn test_story(story: Value) {
             encoder.encode(None, &mut input.clone().into_iter(), &mut buf);
 
             decoder
-                .decode(&mut Cursor::new(buf.into()), |e| {
+                .decode(&mut Cursor::new(&mut buf), |e| {
                     assert_eq!(e, input.remove(0).reify().unwrap());
                 })
                 .unwrap();

--- a/src/hpack/test/fuzz.rs
+++ b/src/hpack/test/fuzz.rs
@@ -149,7 +149,7 @@ impl FuzzHpack {
 
                         // Decode the chunk!
                         decoder
-                            .decode(&mut Cursor::new(buf.into()), |e| {
+                            .decode(&mut Cursor::new(&mut buf), |e| {
                                 assert_eq!(e, expect.remove(0).reify().unwrap());
                             })
                             .unwrap();
@@ -161,7 +161,7 @@ impl FuzzHpack {
 
             // Decode the chunk!
             decoder
-                .decode(&mut Cursor::new(buf.into()), |e| {
+                .decode(&mut Cursor::new(&mut buf), |e| {
                     assert_eq!(e, expect.remove(0).reify().unwrap());
                 })
                 .unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -363,6 +363,10 @@ where
             codec.set_max_recv_frame_size(max as usize);
         }
 
+        if let Some(max) = builder.settings.max_header_list_size() {
+            codec.set_max_recv_header_list_size(max as usize);
+        }
+
         // Send initial settings frame.
         codec
             .buffer(builder.settings.clone().into())
@@ -574,6 +578,12 @@ impl Builder {
     /// above.
     pub fn max_frame_size(&mut self, max: u32) -> &mut Self {
         self.settings.set_max_frame_size(Some(max));
+        self
+    }
+
+    /// Set the max size of received header frames.
+    pub fn max_header_list_size(&mut self, max: u32) -> &mut Self {
+        self.settings.set_max_header_list_size(Some(max));
         self
     }
 

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -573,7 +573,7 @@ fn recv_too_big_headers() {
         .idle_ms(10)
         .close();
 
-    let client = Client::builder()
+    let client = client::Builder::new()
         .max_header_list_size(10)
         .handshake::<_, Bytes>(io)
         .expect("handshake")

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -544,6 +544,82 @@ fn sending_request_on_closed_connection() {
     h2.join(srv).wait().expect("wait");
 }
 
+#[test]
+fn recv_too_big_headers() {
+    let _ = ::env_logger::init();
+    let (io, srv) = mock::new();
+
+    let srv = srv.assert_client_handshake()
+        .unwrap()
+        .recv_custom_settings(
+            frames::settings()
+                .max_header_list_size(10)
+        )
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .recv_frame(
+            frames::headers(3)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .send_frame(frames::headers(1).response(200).eos())
+        .send_frame(frames::headers(3).response(200))
+        // no reset for 1, since it's closed anyways
+        // but reset for 3, since server hasn't closed stream
+        .recv_frame(frames::reset(3).refused())
+        .idle_ms(10)
+        .close();
+
+    let client = Client::builder()
+        .max_header_list_size(10)
+        .handshake::<_, Bytes>(io)
+        .expect("handshake")
+        .and_then(|(mut client, conn)| {
+            let request = Request::builder()
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+
+            let req1 = client
+                .send_request(request, true)
+                .expect("send_request")
+                .0
+                .expect_err("response1")
+                .map(|err| {
+                    assert_eq!(
+                        err.reason(),
+                        Some(Reason::REFUSED_STREAM)
+                    );
+                });
+
+            let request = Request::builder()
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+
+            let req2 = client
+                .send_request(request, true)
+                .expect("send_request")
+                .0
+                .expect_err("response2")
+                .map(|err| {
+                    assert_eq!(
+                        err.reason(),
+                        Some(Reason::REFUSED_STREAM)
+                    );
+                });
+
+            conn.drive(req1.join(req2))
+                .and_then(|(conn, _)| conn.expect("client"))
+        });
+
+    client.join(srv).wait().expect("wait");
+
+}
+
 const SETTINGS: &'static [u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
 const SETTINGS_ACK: &'static [u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -12,6 +12,7 @@ fn read_none() {
 }
 
 #[test]
+#[ignore]
 fn read_frame_too_big() {}
 
 // ===== DATA =====
@@ -100,13 +101,72 @@ fn read_data_stream_id_zero() {
 // ===== HEADERS =====
 
 #[test]
+#[ignore]
 fn read_headers_without_pseudo() {}
 
 #[test]
+#[ignore]
 fn read_headers_with_pseudo() {}
 
 #[test]
+#[ignore]
 fn read_headers_empty_payload() {}
+
+#[test]
+fn read_continuation_frames() {
+    let _ = ::env_logger::init();
+    let (io, srv) = mock::new();
+
+    let large = build_large_headers();
+    let frame = large.iter().fold(
+        frames::headers(1).response(200),
+        |frame, &(name, ref value)| frame.field(name, &value[..]),
+    ).eos();
+
+    let srv = srv.assert_client_handshake()
+        .unwrap()
+        .recv_settings()
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .send_frame(frame)
+        .close();
+
+    let client = Client::handshake(io)
+        .expect("handshake")
+        .and_then(|(mut client, conn)| {
+            let request = Request::builder()
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+
+            let req = client
+                .send_request(request, true)
+                .expect("send_request")
+                .0
+                .expect("response")
+                .map(move |res| {
+                    assert_eq!(res.status(), StatusCode::OK);
+                    let (head, _body) = res.into_parts();
+                    let expected = large.iter().fold(HeaderMap::new(), |mut map, &(name, ref value)| {
+                        use support::frames::HttpTryInto;
+                        map.append(name, value.as_str().try_into().unwrap());
+                        map
+                    });
+                    assert_eq!(head.headers, expected);
+                });
+
+            conn.drive(req)
+                .and_then(move |(h2, _)| {
+                    h2.expect("client")
+                })
+        });
+
+    client.join(srv).wait().expect("wait");
+
+}
 
 #[test]
 fn update_max_frame_len_at_rest() {

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -134,7 +134,7 @@ fn read_continuation_frames() {
         .send_frame(frame)
         .close();
 
-    let client = Client::handshake(io)
+    let client = client::handshake(io)
         .expect("handshake")
         .and_then(|(mut client, conn)| {
             let request = Request::builder()

--- a/tests/codec_write.rs
+++ b/tests/codec_write.rs
@@ -59,28 +59,3 @@ fn write_continuation_frames() {
 
     client.join(srv).wait().expect("wait");
 }
-
-fn build_large_headers() -> Vec<(&'static str, String)> {
-    vec![
-        ("one", "hello".to_string()),
-        ("two", build_large_string('2', 4 * 1024)),
-        ("three", "three".to_string()),
-        ("four", build_large_string('4', 4 * 1024)),
-        ("five", "five".to_string()),
-        ("six", build_large_string('6', 4 * 1024)),
-        ("seven", "seven".to_string()),
-        ("eight", build_large_string('8', 4 * 1024)),
-        ("nine", "nine".to_string()),
-        ("ten", build_large_string('0', 4 * 1024)),
-    ]
-}
-
-fn build_large_string(ch: char, len: usize) -> String {
-    let mut ret = String::new();
-
-    for _ in 0..len {
-        ret.push(ch);
-    }
-
-    ret
-}

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -159,7 +159,7 @@ fn recv_push_promise_over_max_header_list_size() {
         .idle_ms(10)
         .close();
 
-    let client = Client::builder()
+    let client = client::Builder::new()
         .max_header_list_size(10)
         .handshake::<_, Bytes>(io)
         .expect("handshake")

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -138,6 +138,56 @@ fn pending_push_promises_reset_when_dropped() {
 }
 
 #[test]
+fn recv_push_promise_over_max_header_list_size() {
+    let _ = ::env_logger::init();
+    let (io, srv) = mock::new();
+
+    let srv = srv.assert_client_handshake()
+        .unwrap()
+        .recv_custom_settings(
+            frames::settings()
+                .max_header_list_size(10)
+        )
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://http2.akamai.com/")
+                .eos(),
+        )
+        .send_frame(frames::push_promise(1, 2).request("GET", "https://http2.akamai.com/style.css"))
+        .recv_frame(frames::reset(2).refused())
+        .send_frame(frames::headers(1).response(200).eos())
+        .idle_ms(10)
+        .close();
+
+    let client = Client::builder()
+        .max_header_list_size(10)
+        .handshake::<_, Bytes>(io)
+        .expect("handshake")
+        .and_then(|(mut client, conn)| {
+            let request = Request::builder()
+                .uri("https://http2.akamai.com/")
+                .body(())
+                .unwrap();
+
+            let req = client
+                .send_request(request, true)
+                .expect("send_request")
+                .0
+                .expect_err("response")
+                .map(|err| {
+                    assert_eq!(
+                        err.reason(),
+                        Some(Reason::REFUSED_STREAM)
+                    );
+                });
+
+            conn.drive(req)
+                .and_then(|(conn, _)| conn.expect("client"))
+        });
+    client.join(srv).wait().expect("wait");
+}
+
+#[test]
 #[ignore]
 fn recv_push_promise_with_unsafe_method_is_stream_error() {
     // for instance, when :method = POST

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -284,7 +284,7 @@ fn too_big_headers_sends_431() {
         .idle_ms(10)
         .close();
 
-    let srv = Server::builder()
+    let srv = server::Builder::new()
         .max_header_list_size(10)
         .handshake::<_, Bytes>(io)
         .expect("handshake")
@@ -320,7 +320,7 @@ fn too_big_headers_sends_reset_after_431_if_not_eos() {
         .recv_frame(frames::reset(1).refused())
         .close();
 
-    let srv = Server::builder()
+    let srv = server::Builder::new()
         .max_header_list_size(10)
         .handshake::<_, Bytes>(io)
         .expect("handshake")

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -261,3 +261,76 @@ fn sends_reset_cancel_when_res_body_is_dropped() {
 
     srv.join(client).wait().expect("wait");
 }
+
+#[test]
+fn too_big_headers_sends_431() {
+    let _ = ::env_logger::init();
+    let (io, client) = mock::new();
+
+    let client = client
+        .assert_server_handshake()
+        .unwrap()
+        .recv_custom_settings(
+            frames::settings()
+                .max_header_list_size(10)
+        )
+        .send_frame(
+            frames::headers(1)
+                .request("GET", "https://example.com/")
+                .field("some-header", "some-value")
+                .eos()
+        )
+        .recv_frame(frames::headers(1).response(431).eos())
+        .idle_ms(10)
+        .close();
+
+    let srv = Server::builder()
+        .max_header_list_size(10)
+        .handshake::<_, Bytes>(io)
+        .expect("handshake")
+        .and_then(|srv| {
+            srv.into_future()
+                .expect("server")
+                .map(|(req, _)| {
+                    assert!(req.is_none(), "req is {:?}", req);
+                })
+        });
+
+    srv.join(client).wait().expect("wait");
+}
+
+#[test]
+fn too_big_headers_sends_reset_after_431_if_not_eos() {
+    let _ = ::env_logger::init();
+    let (io, client) = mock::new();
+
+    let client = client
+        .assert_server_handshake()
+        .unwrap()
+        .recv_custom_settings(
+            frames::settings()
+                .max_header_list_size(10)
+        )
+        .send_frame(
+            frames::headers(1)
+                .request("GET", "https://example.com/")
+                .field("some-header", "some-value")
+        )
+        .recv_frame(frames::headers(1).response(431).eos())
+        .recv_frame(frames::reset(1).refused())
+        .close();
+
+    let srv = Server::builder()
+        .max_header_list_size(10)
+        .handshake::<_, Bytes>(io)
+        .expect("handshake")
+        .and_then(|srv| {
+            srv.into_future()
+                .expect("server")
+                .map(|(req, _)| {
+                    assert!(req.is_none(), "req is {:?}", req);
+                })
+        });
+
+    srv.join(client).wait().expect("wait");
+}

--- a/tests/support/frames.rs
+++ b/tests/support/frames.rs
@@ -304,6 +304,11 @@ impl Mock<frame::Settings> {
         self.0.set_initial_window_size(Some(val));
         self
     }
+
+    pub fn max_header_list_size(mut self, val: u32) -> Self {
+        self.0.set_max_header_list_size(Some(val));
+        self
+    }
 }
 
 impl From<Mock<frame::Settings>> for frame::Settings {

--- a/tests/support/frames.rs
+++ b/tests/support/frames.rs
@@ -152,6 +152,10 @@ impl Mock<frame::Headers> {
         self
     }
 
+    pub fn into_fields(self) -> HeaderMap {
+        self.0.into_parts().1
+    }
+
     fn into_parts(self) -> (StreamId, frame::Pseudo, HeaderMap) {
         assert!(!self.0.is_end_stream(), "eos flag will be lost");
         assert!(self.0.is_end_headers(), "unset eoh will be lost");

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -394,12 +394,13 @@ pub trait HandleFutureExt {
         self.recv_custom_settings(frame::Settings::default())
     }
 
-    fn recv_custom_settings(self, settings: frame::Settings)
+    fn recv_custom_settings<T>(self, settings: T)
         -> RecvFrame<Box<Future<Item = (Option<Frame>, Handle), Error = ()>>>
     where
         Self: Sized + 'static,
         Self: Future<Item = (frame::Settings, Handle)>,
         Self::Error: fmt::Debug,
+        T: Into<frame::Settings>,
     {
         let map = self
             .map(|(settings, handle)| (Some(settings.into()), handle))
@@ -409,7 +410,7 @@ pub trait HandleFutureExt {
             Box::new(map);
         RecvFrame {
             inner: boxed,
-            frame: settings.into(),
+            frame: settings.into().into(),
         }
     }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -64,3 +64,4 @@ pub type Codec<T> = h2::Codec<T, ::std::io::Cursor<::bytes::Bytes>>;
 
 // This is the frame type that is sent
 pub type SendFrame = h2::frame::Frame<::std::io::Cursor<::bytes::Bytes>>;
+

--- a/tests/support/prelude.rs
+++ b/tests/support/prelude.rs
@@ -85,3 +85,28 @@ where
         }
     }
 }
+
+pub fn build_large_headers() -> Vec<(&'static str, String)> {
+    vec![
+        ("one", "hello".to_string()),
+        ("two", build_large_string('2', 4 * 1024)),
+        ("three", "three".to_string()),
+        ("four", build_large_string('4', 4 * 1024)),
+        ("five", "five".to_string()),
+        ("six", build_large_string('6', 4 * 1024)),
+        ("seven", "seven".to_string()),
+        ("eight", build_large_string('8', 4 * 1024)),
+        ("nine", "nine".to_string()),
+        ("ten", build_large_string('0', 4 * 1024)),
+    ]
+}
+
+fn build_large_string(ch: char, len: usize) -> String {
+    let mut ret = String::new();
+
+    for _ in 0..len {
+        ret.push(ch);
+    }
+
+    ret
+}


### PR DESCRIPTION
This, uh, grew into something far bigger than expected, but it turns out, all of it was needed to eventually support this correctly.

- Adds configuration to client and server to set [SETTINGS_MAX_HEADER_LIST_SIZE](http://httpwg.org/specs/rfc7540.html#SETTINGS_MAX_HEADER_LIST_SIZE)
- If not set, a "sane default" of 16 MB is used (taken from golang's http2)
- Decoding header blocks now happens as they are received, instead of buffering up possibly forever until the last continuation frame is parsed.
- As each field is decoded, it's undecoded size is added to the total. Whenever a header block goes over the maximum size, the `frame` will be marked as such.
- Whenever a header block is deemed over max limit, decoding will still continue, but new fields will not be appended to `HeaderMap`. This is also can save wasted hashing.
- To protect against enormous string literals, such that they span multiple continuation frames, a check is made that the combined encoded bytes is less than the max allowed size. While technically not exactly what the spec suggests (counting decoded size instead), this should hopefully only happen when someone is indeed malicious. If found, a `GOAWAY` of `COMPRESSION_ERROR` is sent, and the connection shut down.
- After an oversize header block frame is finished decoding, the streams state machine will notice it is oversize, and handle that.
  - If the local peer is a server, a 431 response is sent, as suggested by the spec.
  - A `REFUSED_STREAM` reset is sent, since we cannot actually give the stream to the user.
- In order to be able to send both the 431 headers frame, and a reset frame afterwards, the scheduled `Canceled` machinery was made more general to a `Scheduled(Reason)` state instead.

Closes #18 
Closes #191 