### PR TITLE
remove erroneous assert when stream has buffered send data

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -370,8 +370,6 @@ impl Prioritize {
 
         // If data is buffered, then schedule the stream for execution
         if stream.buffered_send_data > 0 {
-            debug_assert!(stream.send_flow.available() > 0);
-
             // TODO: This assertion isn't *exactly* correct. There can still be
             // buffered send data while the stream's pending send queue is
             // empty. This can happen when a large data frame is in the process


### PR DESCRIPTION
This assertion just seems wrong. It doesn't matter if there is still available window for the stream if there was room to buffer the frame to send. Or am I misunderstanding what this assertion is trying to check?

Closes #208 