### PR TITLE
Remove assert around self.pending_capacity.is_empty() (#224)

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -353,9 +353,6 @@ impl Prioritize {
 
         // First check if capacity is immediately available
         if conn_available > 0 {
-            // There should be no streams pending capacity
-            debug_assert!(self.pending_capacity.is_empty());
-
             // The amount of capacity to assign to the stream
             // TODO: Should prioritization factor into this?
             let assign = cmp::min(conn_available, additional);

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -353,6 +353,9 @@ impl Prioritize {
 
         // First check if capacity is immediately available
         if conn_available > 0 {
+            // There should be no streams pending capacity
+            debug_assert!(self.pending_capacity.is_empty());
+
             // The amount of capacity to assign to the stream
             // TODO: Should prioritization factor into this?
             let assign = cmp::min(conn_available, additional);

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -215,10 +215,6 @@ where
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.indices.is_none()
-    }
-
     pub fn take(&mut self) -> Self {
         Queue {
             indices: self.indices.take(),

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -215,6 +215,10 @@ where
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_none()
+    }
+
     pub fn take(&mut self) -> Self {
         Queue {
             indices: self.indices.take(),

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -29,8 +29,8 @@ macro_rules! try_ready {
 
 macro_rules! try_nb {
     ($e:expr) => ({
-        use $crate::support::futures::Async;
         use ::std::io::ErrorKind::WouldBlock;
+        use $crate::support::futures::Async;
 
         match $e {
             Ok(t) => t,
@@ -59,9 +59,11 @@ mod future_ext;
 
 pub use self::future_ext::{FutureExt, Unwrap};
 
+pub type WindowSize = usize;
+pub const DEFAULT_WINDOW_SIZE: WindowSize = (1 << 16) - 1;
+
 // This is our test Codec type
 pub type Codec<T> = h2::Codec<T, ::std::io::Cursor<::bytes::Bytes>>;
 
 // This is the frame type that is sent
 pub type SendFrame = h2::frame::Frame<::std::io::Cursor<::bytes::Bytes>>;
-


### PR DESCRIPTION
This assert does not hold as many streams can be pushed into
pending_capacity during a call to send_data(). See issue #224
for more discussion and sign-off.