### PR TITLE
Upgrade to env_logger 0.5 & log 0.4; reduce related dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio-io = "0.1.4"
 bytes = "0.4"
 http = "0.1"
 byteorder = "1.0"
-log = "0.3.8"
+log = "0.4.1"
 fnv = "1.0.5"
 slab = "0.4.0"
 string = "0.1"
@@ -41,7 +41,7 @@ ordermap = "0.2"
 tokio-timer = "0.1"
 
 # Fuzzing
-quickcheck = "0.4.1"
+quickcheck = { version = "0.4.1", default-features = false }
 rand = "0.3.15"
 
 # HPACK fixtures
@@ -52,7 +52,7 @@ serde_json = "1.0.0"
 
 # Akamai example
 tokio-core = "0.1"
-env_logger = "0.4.3"
+env_logger = { version = "0.5.3", default-features = false }
 rustls = "0.12"
 tokio-rustls = "0.5.0"
 webpki = "0.18.0-alpha"

--- a/examples/akamai.rs
+++ b/examples/akamai.rs
@@ -25,7 +25,7 @@ use std::net::ToSocketAddrs;
 const ALPN_H2: &str = "h2";
 
 pub fn main() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let tls_client_config = std::sync::Arc::new({
         let mut c = rustls::ClientConfig::new();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -45,7 +45,7 @@ impl Future for Process {
 }
 
 pub fn main() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mut core = reactor::Core::new().unwrap();
     let handle = core.handle();

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -15,7 +15,7 @@ use tokio_core::net::TcpListener;
 use tokio_core::reactor;
 
 pub fn main() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mut core = reactor::Core::new().unwrap();
     let handle = core.handle();

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -6,7 +6,7 @@ use support::prelude::*;
 
 #[test]
 fn handshake() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -23,7 +23,7 @@ fn handshake() {
 
 #[test]
 fn client_other_thread() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -60,7 +60,7 @@ fn client_other_thread() {
 
 #[test]
 fn recv_invalid_server_stream_id() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -96,7 +96,7 @@ fn recv_invalid_server_stream_id() {
 
 #[test]
 fn request_stream_id_overflows() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
 
@@ -159,7 +159,7 @@ fn request_stream_id_overflows() {
 
 #[test]
 fn client_builder_max_concurrent_streams() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -199,7 +199,7 @@ fn client_builder_max_concurrent_streams() {
 
 #[test]
 fn request_over_max_concurrent_streams_errors() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
 
@@ -284,7 +284,7 @@ fn request_over_max_concurrent_streams_errors() {
 
 #[test]
 fn http_11_request_without_scheme_or_authority() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -321,7 +321,7 @@ fn http_11_request_without_scheme_or_authority() {
 
 #[test]
 fn http_2_request_without_scheme_or_authority() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -359,7 +359,7 @@ fn request_with_h1_version() {}
 
 #[test]
 fn request_with_connection_headers() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -397,7 +397,7 @@ fn request_with_connection_headers() {
 
 #[test]
 fn connection_close_notifies_response_future() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -440,7 +440,7 @@ fn connection_close_notifies_response_future() {
 
 #[test]
 fn connection_close_notifies_client_poll_ready() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -490,7 +490,7 @@ fn connection_close_notifies_client_poll_ready() {
 
 #[test]
 fn sending_request_on_closed_connection() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -555,7 +555,7 @@ fn sending_request_on_closed_connection() {
 
 #[test]
 fn recv_too_big_headers() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()

--- a/tests/codec_read.rs
+++ b/tests/codec_read.rs
@@ -114,7 +114,7 @@ fn read_headers_empty_payload() {}
 
 #[test]
 fn read_continuation_frames() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let large = build_large_headers();
@@ -170,7 +170,7 @@ fn read_continuation_frames() {
 
 #[test]
 fn update_max_frame_len_at_rest() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     // TODO: add test for updating max frame length in flight as well?
     let mut codec = raw_codec! {
         read => [

--- a/tests/codec_write.rs
+++ b/tests/codec_write.rs
@@ -6,7 +6,7 @@ use support::prelude::*;
 fn write_continuation_frames() {
     // An invalid dependency ID results in a stream level error. The hpack
     // payload should still be decoded.
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let large = build_large_headers();

--- a/tests/flow_control.rs
+++ b/tests/flow_control.rs
@@ -6,7 +6,7 @@ use support::prelude::*;
 // explicitly requested.
 #[test]
 fn send_data_without_requesting_capacity() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = [0; 1024];
 
@@ -52,7 +52,7 @@ fn send_data_without_requesting_capacity() {
 
 #[test]
 fn release_capacity_sends_window_update() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = vec![0u8; 16_384];
 
@@ -126,7 +126,7 @@ fn release_capacity_sends_window_update() {
 
 #[test]
 fn release_capacity_of_small_amount_does_not_send_window_update() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = [0; 16];
 
@@ -190,7 +190,7 @@ fn expand_window_calls_are_coalesced() {}
 
 #[test]
 fn recv_data_overflows_connection_window() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let (io, srv) = mock::new();
 
@@ -257,7 +257,7 @@ fn recv_data_overflows_connection_window() {
 #[test]
 fn recv_data_overflows_stream_window() {
     // this tests for when streams have smaller windows than their connection
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let (io, srv) = mock::new();
 
@@ -324,7 +324,7 @@ fn recv_window_update_causes_overflow() {
 
 #[test]
 fn stream_error_release_connection_capacity() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -395,7 +395,7 @@ fn stream_error_release_connection_capacity() {
 
 #[test]
 fn stream_close_by_data_frame_releases_capacity() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
@@ -466,7 +466,7 @@ fn stream_close_by_data_frame_releases_capacity() {
 
 #[test]
 fn stream_close_by_trailers_frame_releases_capacity() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let window_size = frame::DEFAULT_INITIAL_WINDOW_SIZE as usize;
@@ -551,7 +551,7 @@ fn stream_close_by_recv_reset_frame_releases_capacity() {}
 
 #[test]
 fn recv_window_update_on_stream_closed_by_data_frame() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let h2 = client::handshake(io)
@@ -600,7 +600,7 @@ fn recv_window_update_on_stream_closed_by_data_frame() {
 
 #[test]
 fn reserved_capacity_assigned_in_multi_window_updates() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let h2 = client::handshake(io)
@@ -685,7 +685,7 @@ fn connection_notified_on_released_capacity() {
     use std::sync::mpsc;
     use std::thread;
 
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     // We're going to run the connection on a thread in order to isolate task
@@ -788,7 +788,7 @@ fn connection_notified_on_released_capacity() {
 
 #[test]
 fn recv_settings_removes_available_capacity() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -846,7 +846,7 @@ fn recv_settings_removes_available_capacity() {
 
 #[test]
 fn recv_no_init_window_then_receive_some_init_window() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -911,7 +911,7 @@ fn settings_lowered_capacity_returns_capacity_to_connection() {
     use std::sync::mpsc;
     use std::thread;
 
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
     let (tx1, rx1) = mpsc::channel();
     let (tx2, rx2) = mpsc::channel();
@@ -1029,7 +1029,7 @@ fn settings_lowered_capacity_returns_capacity_to_connection() {
 
 #[test]
 fn client_increase_target_window_size() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1051,7 +1051,7 @@ fn client_increase_target_window_size() {
 
 #[test]
 fn increase_target_window_size_after_using_some() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1091,7 +1091,7 @@ fn increase_target_window_size_after_using_some() {
 
 #[test]
 fn decrease_target_window_size() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -1139,7 +1139,7 @@ fn decrease_target_window_size() {
 
 #[test]
 fn server_target_window_size() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client.assert_server_handshake()
@@ -1161,7 +1161,7 @@ fn server_target_window_size() {
 #[test]
 fn recv_settings_increase_window_size_after_using_some() {
     // See https://github.com/carllerche/h2/issues/208
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let new_win_size = 16_384 * 4; // 1 bigger than default

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -4,7 +4,7 @@ use support::prelude::*;
 
 #[test]
 fn recv_single_ping() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (m, mock) = mock::new();
 
     // Create the handshake
@@ -40,7 +40,7 @@ fn recv_single_ping() {
 
 #[test]
 fn recv_multiple_pings() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client.assert_server_handshake()
@@ -64,7 +64,7 @@ fn recv_multiple_pings() {
 
 #[test]
 fn pong_has_highest_priority() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let data = Bytes::from(vec![0; 16_384]);

--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -4,7 +4,7 @@ use support::prelude::*;
 
 #[test]
 fn single_stream_send_large_body() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = [0; 1024];
 
@@ -67,7 +67,7 @@ fn single_stream_send_large_body() {
 
 #[test]
 fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = vec![0; 32_768];
 
@@ -134,7 +134,7 @@ fn single_stream_send_extra_large_body_multi_frames_one_buffer() {
 
 #[test]
 fn single_stream_send_body_greater_than_default_window() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = vec![0; 16384*5-1];
 
@@ -227,7 +227,7 @@ fn single_stream_send_body_greater_than_default_window() {
 
 #[test]
 fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = vec![0; 32_768];
 
@@ -293,7 +293,7 @@ fn single_stream_send_extra_large_body_multi_frames_multi_buffer() {
 
 #[test]
 fn send_data_receive_window_update() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (m, mock) = mock::new();
 
     let h2 = client::handshake(m)

--- a/tests/push_promise.rs
+++ b/tests/push_promise.rs
@@ -5,7 +5,7 @@ use support::prelude::*;
 fn recv_push_works() {
     // tests that by default, received push promises work
     // TODO: once API exists, read the pushed response
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -43,7 +43,7 @@ fn recv_push_works() {
 
 #[test]
 fn recv_push_when_push_disabled_is_conn_error() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let (io, srv) = mock::new();
     let mock = srv.assert_client_handshake()
@@ -96,7 +96,7 @@ fn recv_push_when_push_disabled_is_conn_error() {
 
 #[test]
 fn pending_push_promises_reset_when_dropped() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let (io, srv) = mock::new();
     let srv = srv.assert_client_handshake()
@@ -139,7 +139,7 @@ fn pending_push_promises_reset_when_dropped() {
 
 #[test]
 fn recv_push_promise_over_max_header_list_size() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -6,7 +6,7 @@ const SETTINGS_ACK: &'static [u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 
 #[test]
 fn read_preface_in_multiple_frames() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .read(b"PRI * HTTP/2.0")
@@ -24,7 +24,7 @@ fn read_preface_in_multiple_frames() {
 
 #[test]
 fn server_builder_set_max_concurrent_streams() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let mut settings = frame::Settings::default();
@@ -74,7 +74,7 @@ fn server_builder_set_max_concurrent_streams() {
 
 #[test]
 fn serve_request() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -111,7 +111,7 @@ fn accept_with_pending_connections_after_socket_close() {}
 
 #[test]
 fn recv_invalid_authority() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let bad_auth = util::byte_str("not:a/good authority");
@@ -138,7 +138,7 @@ fn recv_invalid_authority() {
 
 #[test]
 fn recv_connection_header() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let req = |id, name, val| {
@@ -173,7 +173,7 @@ fn recv_connection_header() {
 
 #[test]
 fn sends_reset_cancel_when_req_body_is_dropped() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -206,7 +206,7 @@ fn sends_reset_cancel_when_req_body_is_dropped() {
 
 #[test]
 fn sends_goaway_when_serv_closes_connection() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -232,7 +232,7 @@ fn sends_goaway_when_serv_closes_connection() {
 
 #[test]
 fn serve_request_then_serv_closes_connection() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -278,7 +278,7 @@ fn serve_request_then_serv_closes_connection() {
 
 #[test]
 fn sends_reset_cancel_when_res_body_is_dropped() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -336,7 +336,7 @@ fn sends_reset_cancel_when_res_body_is_dropped() {
 
 #[test]
 fn too_big_headers_sends_431() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client
@@ -373,7 +373,7 @@ fn too_big_headers_sends_431() {
 
 #[test]
 fn too_big_headers_sends_reset_after_431_if_not_eos() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
     let client = client

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -6,7 +6,7 @@ use support::prelude::*;
 
 #[test]
 fn send_recv_headers_only() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -39,7 +39,7 @@ fn send_recv_headers_only() {
 
 #[test]
 fn send_recv_data() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -102,7 +102,7 @@ fn send_recv_data() {
 
 #[test]
 fn send_headers_recv_data_single_frame() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -151,7 +151,7 @@ fn send_headers_recv_data_single_frame() {
 
 #[test]
 fn closed_streams_are_released() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
@@ -196,7 +196,7 @@ fn closed_streams_are_released() {
 
 #[test]
 fn errors_if_recv_frame_exceeds_max_frame_size() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, mut srv) = mock::new();
 
     let h2 = client::handshake(io).unwrap().and_then(|(mut client, h2)| {
@@ -251,7 +251,7 @@ fn errors_if_recv_frame_exceeds_max_frame_size() {
 
 #[test]
 fn configure_max_frame_size() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, mut srv) = mock::new();
 
     let h2 = client::Builder::new()
@@ -302,7 +302,7 @@ fn configure_max_frame_size() {
 
 #[test]
 fn recv_goaway_finishes_processed_streams() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -371,7 +371,7 @@ fn recv_goaway_finishes_processed_streams() {
 
 #[test]
 fn recv_next_stream_id_updated_by_malformed_headers() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
 
@@ -414,7 +414,7 @@ fn recv_next_stream_id_updated_by_malformed_headers() {
 
 #[test]
 fn skipped_stream_ids_are_implicitly_closed() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv
@@ -468,7 +468,7 @@ fn skipped_stream_ids_are_implicitly_closed() {
 
 #[test]
 fn send_rst_stream_allows_recv_data() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -520,7 +520,7 @@ fn send_rst_stream_allows_recv_data() {
 
 #[test]
 fn send_rst_stream_allows_recv_trailers() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -569,7 +569,7 @@ fn send_rst_stream_allows_recv_trailers() {
 
 #[test]
 fn rst_stream_expires() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -631,7 +631,7 @@ fn rst_stream_expires() {
 
 #[test]
 fn rst_stream_max() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -721,7 +721,7 @@ fn rst_stream_max() {
 
 #[test]
 fn reserved_state_recv_window_update() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
     let srv = srv.assert_client_handshake()
@@ -773,7 +773,7 @@ fn reserved_state_recv_window_update() {
 /*
 #[test]
 fn send_data_after_headers_eos() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()

--- a/tests/trailers.rs
+++ b/tests/trailers.rs
@@ -6,7 +6,7 @@ use support::prelude::*;
 
 #[test]
 fn recv_trailers_only() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()
@@ -52,7 +52,7 @@ fn recv_trailers_only() {
 
 #[test]
 fn send_trailers_immediately() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mock = mock_io::Builder::new()
         .handshake()


### PR DESCRIPTION
Upgrade to env_logger 0.5 and log 0.4 so that projects that use those
versions don't have to build both those versions and the older ones
that h2 is currently using.

Don't enable the regex support in env_logger. Applications that want
the regex support can enable it themselves; this will happen
automatically when they add their env_logger dependency.

Disable the env_logger dependency in quickcheck.

The result of this is that there are fewer dependencies. For example,
regex and its dependencies are no longer required at all, as can be
seen by observing the changes to the Cargo.lock. That said,
env_logger 0.5 does add more dependencies itself; however it seems
applications are going to use env_logger 0.5 anyway so this is still
a net gain.

Submitted on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>