### PR TITLE
Upgrade ordermap dependency to indexmap.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.1"
 fnv = "1.0.5"
 slab = "0.4.0"
 string = "0.1"
-ordermap = "0.2"
+indexmap = "0.4"
 
 [dev-dependencies]
 tokio-timer = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ extern crate slab;
 #[macro_use]
 extern crate log;
 extern crate string;
-extern crate ordermap;
+extern crate indexmap;
 
 mod error;
 #[cfg_attr(feature = "unstable", allow(missing_docs))]

--- a/src/proto/streams/store.rs
+++ b/src/proto/streams/store.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use slab;
 
-use ordermap::{self, OrderMap};
+use indexmap::{self, IndexMap};
 
 use std::marker::PhantomData;
 use std::ops;
@@ -11,7 +11,7 @@ use std::ops;
 #[derive(Debug)]
 pub(super) struct Store {
     slab: slab::Slab<(StoreId, Stream)>,
-    ids: OrderMap<StreamId, (usize, StoreId)>,
+    ids: IndexMap<StreamId, (usize, StoreId)>,
     counter: StoreId,
 }
 
@@ -61,11 +61,11 @@ pub(super) enum Entry<'a> {
 }
 
 pub(super) struct OccupiedEntry<'a> {
-    ids: ordermap::OccupiedEntry<'a, StreamId, (usize, StoreId)>,
+    ids: indexmap::map::OccupiedEntry<'a, StreamId, (usize, StoreId)>,
 }
 
 pub(super) struct VacantEntry<'a> {
-    ids: ordermap::VacantEntry<'a, StreamId, (usize, StoreId)>,
+    ids: indexmap::map::VacantEntry<'a, StreamId, (usize, StoreId)>,
     slab: &'a mut slab::Slab<(StoreId, Stream)>,
     counter: &'a mut usize,
 }
@@ -80,7 +80,7 @@ impl Store {
     pub fn new() -> Self {
         Store {
             slab: slab::Slab::new(),
-            ids: OrderMap::new(),
+            ids: IndexMap::new(),
             counter: 0,
         }
     }
@@ -116,7 +116,7 @@ impl Store {
     }
 
     pub fn find_entry(&mut self, id: StreamId) -> Entry {
-        use self::ordermap::Entry::*;
+        use self::indexmap::map::Entry::*;
 
         match self.ids.entry(id) {
             Occupied(e) => Entry::Occupied(OccupiedEntry {


### PR DESCRIPTION
Avoid the need for indexmap-based applications to build ordermap,
which is the old name for indexmap.

Signed-off-by: Brian Smith <brian@briansmith.org>