### PR TITLE
Normalize HTTP request path.

### DIFF
--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -440,10 +440,14 @@ impl Pseudo {
     pub fn request(method: Method, uri: Uri) -> Self {
         let parts = uri::Parts::from(uri);
 
-        let path = parts
+        let mut path = parts
             .path_and_query
             .map(|v| v.into())
-            .unwrap_or_else(|| Bytes::from_static(b"/"));
+            .unwrap_or_else(|| Bytes::new());
+
+        if path.is_empty() && method != Method::OPTIONS {
+            path = Bytes::from_static(b"/");
+        }
 
         let mut pseudo = Pseudo {
             method: Some(method),

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -273,7 +273,6 @@ impl fmt::Debug for Headers {
             .field("stream_id", &self.stream_id)
             .field("stream_dep", &self.stream_dep)
             .field("flags", &self.flags)
-            .field("header_block", &self.header_block)
             // `fields` and `pseudo` purposefully not included
             .finish()
     }

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -273,6 +273,7 @@ impl fmt::Debug for Headers {
             .field("stream_id", &self.stream_id)
             .field("stream_dep", &self.stream_dep)
             .field("flags", &self.flags)
+            .field("header_block", &self.header_block)
             // `fields` and `pseudo` purposefully not included
             .finish()
     }

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -658,6 +658,44 @@ fn request_without_path() {
     client.join(srv).wait().unwrap();
 }
 
+#[test]
+fn request_options_with_star() {
+    let _ = ::env_logger::try_init();
+    let (io, srv) = mock::new();
+
+    let uri = uri::Uri::from_parts({
+        let mut parts = uri::Parts::default();
+        parts.scheme = Some(uri::Scheme::HTTP);
+        parts.authority = Some(uri::Authority::from_shared("example.com".into()).unwrap());
+        parts.path_and_query = Some(uri::PathAndQuery::from_static("*"));
+        parts
+    }).unwrap();
+
+    let srv = srv.assert_client_handshake()
+        .unwrap()
+        .recv_settings()
+        .recv_frame(frames::headers(1).request("OPTIONS", uri.clone()).eos())
+        .send_frame(frames::headers(1).response(200).eos())
+        .close();
+
+    let client = client::handshake(io)
+        .expect("handshake")
+        .and_then(move |(mut client, conn)| {
+            // Note the lack of trailing slash.
+            let request = Request::builder()
+                .method(Method::OPTIONS)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            let (response, _) = client.send_request(request, true).unwrap();
+
+            conn.drive(response)
+        });
+
+    client.join(srv).wait().unwrap();
+}
+
 const SETTINGS: &'static [u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
 const SETTINGS_ACK: &'static [u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -663,6 +663,7 @@ fn request_options_with_star() {
     let _ = ::env_logger::try_init();
     let (io, srv) = mock::new();
 
+    // Note the lack of trailing slash.
     let uri = uri::Uri::from_parts({
         let mut parts = uri::Parts::default();
         parts.scheme = Some(uri::Scheme::HTTP);
@@ -681,7 +682,6 @@ fn request_options_with_star() {
     let client = client::handshake(io)
         .expect("handshake")
         .and_then(move |(mut client, conn)| {
-            // Note the lack of trailing slash.
             let request = Request::builder()
                 .method(Method::OPTIONS)
                 .uri(uri)

--- a/tests/client_request.rs
+++ b/tests/client_request.rs
@@ -630,6 +630,34 @@ fn recv_too_big_headers() {
 
 }
 
+#[test]
+fn request_without_path() {
+    let _ = ::env_logger::try_init();
+    let (io, srv) = mock::new();
+
+    let srv = srv.assert_client_handshake()
+        .unwrap()
+        .recv_settings()
+        .recv_frame(frames::headers(1).request("GET", "http://example.com/").eos())
+        .send_frame(frames::headers(1).response(200).eos())
+        .close();
+
+    let client = client::handshake(io)
+        .expect("handshake")
+        .and_then(move |(mut client, conn)| {
+            // Note the lack of trailing slash.
+            let request = Request::get("http://example.com")
+                .body(())
+                .unwrap();
+
+            let (response, _) = client.send_request(request, true).unwrap();
+
+            conn.drive(response)
+        });
+
+    client.join(srv).wait().unwrap();
+}
+
 const SETTINGS: &'static [u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
 const SETTINGS_ACK: &'static [u8] = &[0, 0, 0, 4, 1, 0, 0, 0, 0];
 

--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -68,7 +68,7 @@ fn single_stream_send_large_body() {
 
 #[test]
 fn multiple_streams_with_payload_greater_than_default_window() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = vec![0; 16384*5-1];
 

--- a/tests/support/prelude.rs
+++ b/tests/support/prelude.rs
@@ -32,7 +32,7 @@ pub use self::futures::{Future, IntoFuture, Sink, Stream};
 pub use super::future_ext::{FutureExt, Unwrap};
 
 // Re-export HTTP types
-pub use self::http::{HeaderMap, Method, Request, Response, StatusCode, Version};
+pub use self::http::{uri, HeaderMap, Method, Request, Response, StatusCode, Version};
 
 pub use self::bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
 


### PR DESCRIPTION
The HTTP/2.0 specification requires that the path pseudo header is never
empty for requests unless the request uses the OPTIONS method.

This is currently not correctly enforced.

This patch provides a test and a fix.