### PR TITLE
notify send_tasks when there is a connection error

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -699,9 +699,6 @@ impl Prioritize {
 
                 counts.inc_num_send_streams();
                 self.pending_send.push(&mut stream);
-                if let Some(task) = stream.open_task.take() {
-                    task.notify();
-                }
             } else {
                 return;
             }

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -595,6 +595,7 @@ impl Recv {
     ) -> Result<(), RecvError> {
         // Notify the stream
         stream.state.recv_reset(frame.reason());
+        stream.notify_send();
         stream.notify_recv();
         Ok(())
     }
@@ -605,6 +606,7 @@ impl Recv {
         stream.state.recv_err(err);
 
         // If a receiver is waiting, notify it
+        stream.notify_send();
         stream.notify_recv();
     }
 

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -64,9 +64,6 @@ pub(super) struct Stream {
     /// Set to true when the stream is pending to be opened
     pub is_pending_open: bool,
 
-    /// Task tracking when stream can be "opened", or initially sent to socket.
-    pub open_task: Option<task::Task>,
-
     // ===== Fields related to receiving =====
     /// Next node in the accept linked list
     pub next_pending_accept: Option<store::Key>,
@@ -168,7 +165,6 @@ impl Stream {
             send_capacity_inc: false,
             is_pending_open: false,
             next_open: None,
-            open_task: None,
 
             // ===== Fields related to receiving =====
             next_pending_accept: None,


### PR DESCRIPTION
If `client::SendRequest` had parked a future with `poll_ready`, and there is a connection error (not eof), that future was never notified.

Also removes `open_task`, as it was dead code.