### PR TITLE
Fix tests by switching to env_logger::try_init

### DIFF
--- a/tests/prioritization.rs
+++ b/tests/prioritization.rs
@@ -68,7 +68,7 @@ fn single_stream_send_large_body() {
 
 #[test]
 fn multiple_streams_with_payload_greater_than_default_window() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let payload = vec![0; 16384*5-1];
 


### PR DESCRIPTION
Running `cargo test --features unstable` was failing because env_logger was already initiated. Use `try_init` like every other test to fix this.