### PR TITLE
Prevent pushing a stream into both pending_send + pending_open

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -407,8 +407,9 @@ impl Prioritize {
         // if there is no room according to the concurrency limit (max_send_streams), and we
         // also allow data to be buffered for send with send_data() if there is no capacity for
         // the stream to send the data, which attempts to place the stream in pending_send.
-        // If the stream is not open, we don't want the stream to be
-        // scheduled for execution (pending_send)
+        // If the stream is not open, we don't want the stream to be scheduled for
+        // execution (pending_send). Note that if the stream is in pending_open, it will be
+        // pushed to pending_send when there is room for an open stream.
         if stream.buffered_send_data > 0 && !stream.is_pending_open {
             // TODO: This assertion isn't *exactly* correct. There can still be
             // buffered send data while the stream's pending send queue is

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -283,18 +283,6 @@ impl Send {
         Ok(())
     }
 
-    pub fn recv_reset<B>(
-        &mut self,
-        buffer: &mut Buffer<Frame<B>>,
-        stream: &mut store::Ptr
-    ) {
-        // Clear all pending outbound frames
-        self.prioritize.clear_queue(buffer, stream);
-
-        // Don't give capacity back to other steams as the
-        // window size is not given back as well
-    }
-
     pub fn recv_err<B>(
         &mut self,
         buffer: &mut Buffer<Frame<B>>,

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -1,8 +1,8 @@
-use http;
-use super::*;
 use codec::{RecvError, UserError};
 use codec::UserError::*;
 use frame::{self, Reason};
+use http;
+use super::*;
 
 use bytes::Buf;
 
@@ -281,6 +281,18 @@ impl Send {
         }
 
         Ok(())
+    }
+
+    pub fn recv_reset<B>(
+        &mut self,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr
+    ) {
+        // Clear all pending outbound frames
+        self.prioritize.clear_queue(buffer, stream);
+
+        // Don't give capacity back to other steams as the
+        // window size is not given back as well
     }
 
     pub fn recv_err<B>(

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -336,6 +336,11 @@ impl store::Next for NextSend {
     }
 
     fn set_queued(stream: &mut Stream, val: bool) {
+        if val {
+            // ensure that stream is not queued for being opened
+            // if it's being put into queue for sending data
+            debug_assert_eq!(stream.is_pending_open, false);
+        }
         stream.is_pending_send = val;
     }
 }
@@ -402,6 +407,11 @@ impl store::Next for NextOpen {
     }
 
     fn set_queued(stream: &mut Stream, val: bool) {
+        if val {
+            // ensure that stream is not queued for being sent
+            // if it's being put into queue for opening the stream
+            debug_assert_eq!(stream.is_pending_send, false);
+        }
         stream.is_pending_open = val;
     }
 }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -255,10 +255,14 @@ where
             },
         };
 
+        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
+        let send_buffer = &mut *send_buffer;
+
         let actions = &mut me.actions;
 
         me.counts.transition(stream, |_, stream| {
             actions.recv.recv_reset(frame, stream)?;
+            actions.send.recv_reset(send_buffer, stream);
             assert!(stream.state.is_closed());
             Ok(())
         })

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -255,14 +255,10 @@ where
             },
         };
 
-        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
-        let send_buffer = &mut *send_buffer;
-
         let actions = &mut me.actions;
 
         me.counts.transition(stream, |_, stream| {
             actions.recv.recv_reset(frame, stream)?;
-            actions.send.recv_reset(send_buffer, stream);
             assert!(stream.state.is_closed());
             Ok(())
         })


### PR DESCRIPTION
Because external users of h2 are allowed to `send_request()` and `send_data()` without blocking, a stream can get pushed into the pending_open queue (waiting for number of streams to go down), and also the pending_send queue (waiting for capacity on the stream / connection). My proposed solution is to prevent streams from being pushed into pending_send queue as streams put in the queue are scheduled to be executed + data should not be sent for a stream that is not open.

There are also newly added asserts that a stream should never be in pending_send and pending_open at the same time.