### PR TITLE
Streams receiving peer reset clear pending send

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -588,16 +588,12 @@ impl Recv {
     }
 
     /// Handle remote sending an explicit RST_STREAM.
-    pub fn recv_reset(
-        &mut self,
-        frame: frame::Reset,
-        stream: &mut Stream,
-    ) -> Result<(), RecvError> {
+    pub fn recv_reset(&mut self, frame: frame::Reset, stream: &mut Stream) {
         // Notify the stream
         stream.state.recv_reset(frame.reason());
+
         stream.notify_send();
         stream.notify_recv();
-        Ok(())
     }
 
     /// Handle a received error

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -283,6 +283,15 @@ impl Send {
         Ok(())
     }
 
+    pub fn recv_reset<B>(
+        &mut self,
+        buffer: &mut Buffer<Frame<B>>,
+        stream: &mut store::Ptr
+    ) {
+        // Clear all pending outbound frames
+        self.prioritize.clear_queue(buffer, stream);
+    }
+
     pub fn recv_err<B>(
         &mut self,
         buffer: &mut Buffer<Frame<B>>,

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -301,6 +301,13 @@ impl State {
         }
     }
 
+    pub fn is_peer_reset(&self) -> bool {
+        match self.inner {
+            Closed(Cause::Proto(_)) => true,
+            _ => false,
+        }
+    }
+
     /// Returns true if the stream is already reset.
     pub fn is_reset(&self) -> bool {
         match self.inner {

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -255,10 +255,14 @@ where
             },
         };
 
+        let mut send_buffer = self.send_buffer.inner.lock().unwrap();
+        let send_buffer = &mut *send_buffer;
+
         let actions = &mut me.actions;
 
         me.counts.transition(stream, |_, stream| {
-            actions.recv.recv_reset(frame, stream)?;
+            actions.recv.recv_reset(frame, stream);
+            actions.send.recv_reset(send_buffer, stream);
             assert!(stream.state.is_closed());
             Ok(())
         })


### PR DESCRIPTION
So, I thought this issue was solved with #235, but actually what was happening was I had both these fixes + #235 previously, and removed these fixes because they didn't seem to be necessary (test code worked fine). Unfortunately, turns out there a race condition external to the h2 crate that was hiding this issue (adding additional logging causes this issue again).

The issue:
Streams that have pending send data and also receive a peer reset are not counted as `is_closed()` after reset. Because these streams were opened, they increment `num_send_streams` which is an internal tracker of the number of open send streams checked against `max_send_streams`. Therefore the connection will believe streams are still in-flight + won't open new streams.

The fix:
Properly call `prioritize.clear_queue()` when receiving a reset. I added two lines which reset `buffered_send_data` and `requested_send_capacity` to 0 which mimics logic from `pop_frame` (when frames are actually sent, they decrement these as well). This means that the stream is marked as `is_closed()` and decrements `num_send_streams` immediately after receiving a RESET.

Additional things: 
* I removed the Result<()> from `state.recv_reset` as it isn't needed and implies that the stream could fail changing the state + not clear the queue.
* We remove the peer reset stream from the `pending_send` queue when popped because otherwise it would be an O(N) traversal to remove it from the queue when receiving a reset.

Alternatives:
Instead of using `is_peer_reset()` we could alternatively have a variable on stream that is set when the queue is reset. That could be used instead when popping streams off `pending_send` and ignoring them.
