### PR TITLE
Add initial_max_send_streams() as builder option

### DIFF
--- a/src/proto/connection.rs
+++ b/src/proto/connection.rs
@@ -46,6 +46,7 @@ where
 #[derive(Debug, Clone)]
 pub(crate) struct Config {
     pub next_stream_id: StreamId,
+    pub initial_max_send_streams: usize,
     pub reset_stream_duration: Duration,
     pub reset_stream_max: usize,
     pub settings: frame::Settings,
@@ -80,7 +81,7 @@ where
             local_init_window_sz: config.settings
                 .initial_window_size()
                 .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE),
-            local_max_initiated: None,
+            initial_max_send_streams: config.initial_max_send_streams,
             local_next_stream_id: config.next_stream_id,
             local_push_enabled: config.settings.is_push_enabled(),
             local_reset_duration: config.reset_stream_duration,

--- a/src/proto/streams/counts.rs
+++ b/src/proto/streams/counts.rs
@@ -32,7 +32,7 @@ impl Counts {
     pub fn new(peer: peer::Dyn, config: &Config) -> Self {
         Counts {
             peer,
-            max_send_streams: config.local_max_initiated.unwrap_or(usize::MAX),
+            max_send_streams: config.initial_max_send_streams,
             num_send_streams: 0,
             max_recv_streams: config.remote_max_initiated.unwrap_or(usize::MAX),
             num_recv_streams: 0,

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -26,17 +26,20 @@ use self::stream::Stream;
 use frame::{StreamId, StreamIdOverflow};
 use proto::*;
 
-use std::time::Duration;
 use bytes::Bytes;
 use http::{Request, Response};
+use std::time::Duration;
 
 #[derive(Debug)]
 pub struct Config {
     /// Initial window size of locally initiated streams
     pub local_init_window_sz: WindowSize,
 
-    /// Maximum number of locally initiated streams
-    pub local_max_initiated: Option<usize>,
+    /// Initial maximum number of locally initiated streams.
+    /// After receiving a Settings frame from the remote peer,
+    /// the connection will overwrite this value with the
+    /// MAX_CONCURRENT_STREAMS specified in the frame.
+    pub initial_max_send_streams: usize,
 
     /// The stream ID to start the next local stream with
     pub local_next_stream_id: StreamId,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1026,6 +1026,8 @@ impl<T, B: IntoBuf> Future for Handshake<T, B>
         let server = poll?.map(|codec| {
             let connection = proto::Connection::new(codec, Config {
                 next_stream_id: 2.into(),
+                // Server does not need to locally initiate any streams
+                initial_max_send_streams: 0,
                 reset_stream_duration: self.builder.reset_stream_duration,
                 reset_stream_max: self.builder.reset_stream_max,
                 settings: self.builder.settings.clone(),


### PR DESCRIPTION
Problem: Establishing a connection to some provider and using the `poll_ready()` function to determine when there is space to establish new streams means that we can send up to `usize::MAX` streams until receiving a `Settings` frame from the remote peer.

Solution: Allow callers to specify an `initial_max_send_streams` which can be used until receiving the `Settings` frame. This will prevent using extraneous bandwidth and an extraneous amount of REFUSED_STREAM resets and can scale up or down the number of streams without causing unnecessary delays.

The default behavior is to keep the `initial_max_send_streams` at `usize::MAX` to keep functionality the same.