### PR TITLE
recv_reset resets closed streams with queued EOS frames

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -575,7 +575,8 @@ impl Prioritize {
         loop {
             match self.pending_send.pop(store) {
                 Some(mut stream) => {
-                    trace!("pop_frame; stream={:?}", stream.id);
+                    trace!("pop_frame; stream={:?}; stream.state={:?}",
+                        stream.id, stream.state);
 
                     // If the stream receives a RESET from the peer, it may have
                     // had data buffered to be sent, but all the frames are cleared

--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -590,7 +590,7 @@ impl Recv {
     /// Handle remote sending an explicit RST_STREAM.
     pub fn recv_reset(&mut self, frame: frame::Reset, stream: &mut Stream) {
         // Notify the stream
-        stream.state.recv_reset(frame.reason());
+        stream.state.recv_reset(frame.reason(), stream.is_pending_send);
 
         stream.notify_send();
         stream.notify_recv();

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -218,10 +218,10 @@ impl State {
 
         match self.inner {
             Closed(Cause::EndStream) if queued => {
-                // If the stream has a queued EOS frame, reschedule it to
-                // drain the queue and reset, instead.
+                // If the stream has a queued EOS frame, transition to peer
+                // reset.
                 trace!("recv_reset: reason={:?}; queued=true", reason);
-                self.inner = Closed(Cause::Scheduled(reason));
+                self.inner = Closed(Cause::Proto(reason));
             },
             Closed(..) => {},
             _ => {

--- a/src/proto/streams/state.rs
+++ b/src/proto/streams/state.rs
@@ -324,14 +324,6 @@ impl State {
         }
     }
 
-    // /// Returns true if the stream was closed by sending an EOS.
-    // pub fn is_eos(&self) -> bool {
-    //     match self.inner {
-    //         Closed(Cause::EndStream) => true,
-    //         _ => false,
-    //     }
-    // }
-
     /// Returns true if a stream is open or half-closed.
     pub fn is_at_least_half_open(&self) -> bool {
         match self.inner {

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -833,8 +833,7 @@ fn rst_while_closing() {
         .idle_ms(1)
         // Send the RST_STREAM frame which causes the client to panic.
         .send_frame(frames::reset(1).cancel())
-        .recv_frame(frames::headers(1).eos())
-        .recv_frame(frames::go_away(0))
+        .recv_frame(frames::reset(1).cancel())
         .close();
 
     let client = client::handshake(io)

--- a/tests/stream_states.rs
+++ b/tests/stream_states.rs
@@ -833,8 +833,9 @@ fn rst_while_closing() {
         .idle_ms(1)
         // Send the RST_STREAM frame which causes the client to panic.
         .send_frame(frames::reset(1).cancel())
-        .recv_frame(frames::reset(1).cancel())
+        .ping_pong([1; 8])
         .close();
+        ;
 
     let client = client::handshake(io)
         .expect("handshake")
@@ -855,8 +856,7 @@ fn rst_while_closing() {
                 .and_then(move |resp| {
                     assert_eq!(resp.status(), StatusCode::OK);
                     // Enqueue trailers frame.
-                    let _ = stream.send_trailers(HeaderMap::new())
-                        .expect("send_trailers");
+                    let _ = stream.send_trailers(HeaderMap::new());
                     Ok(())
                 })
                 .map_err(|()| -> Error {


### PR DESCRIPTION
Fixes #246. Fixes runconduit/conduit#607.

An issue currently exists where `h2` will panic when a stream transitions from `HalfClosed(remote)` to `Closed(Cause::EndStream)` by enqueuing an EOS frame, and then receives a `RST_STREAM` frame _before_ the queued EOS frame is sent.

In this case, the `expect` in `prioritize::pop_frame` https://github.com/carllerche/h2/blob/f8baeb7211985834acaf7ecc70548aafd5d9ef6d/src/proto/streams/prioritize.rs#L693-L694 is called on a frame which does _not_ have a scheduled reset, because it is in the `Closed(Cause::EndStream)` state. However, the guard which skips this code when the stream is peer reset https://github.com/carllerche/h2/blob/f8baeb7211985834acaf7ecc70548aafd5d9ef6d/src/proto/streams/prioritize.rs#L584-L586 doesn't cause us to skip in this case, because the stream is in the `Closed(Cause::EndStream)` state.

---

I've modified [`streams::State::recv_reset`](
https://github.com/hawkw/h2/blob/14200321d77aaf31e57fe7c40d4223030e113922/src/proto/streams/state.rs#L217-L232) to take a boolean parameter indicating whether the stream receiving a reset currently has a frame queued to send. If the stream is in the `Closed(Cause::EndStream)` state, rather than doing nothing, we check whether there is a queued frame. If so, the stream transitions to `Closed(Cause::Proto)` with the reason for the received reset set as the reason. 

This way, when `prioritize::pop_frame` sees this stream, it will be treated by any other reset stream, draining the queue and transitioning to reset. We no longer hit the `expect` call that was causing panics in this case.

I've also added a unit test that reproduces the crash against master.