### PR TITLE
Reset queued streams on `recv_err`

### DIFF
--- a/src/proto/streams/recv.rs
+++ b/src/proto/streams/recv.rs
@@ -609,7 +609,7 @@ impl Recv {
     /// Handle a received error
     pub fn recv_err(&mut self, err: &proto::Error, stream: &mut Stream) {
         // Receive an error
-        stream.state.recv_err(err);
+        stream.state.recv_err(err, stream.is_pending_send);
 
         // If a receiver is waiting, notify it
         stream.notify_send();


### PR DESCRIPTION
See https://github.com/carllerche/h2/pull/258#issuecomment-381768145 --- the same changes made in `recv_reset` in #258 should also probably be made in `recv_err`.