### PR TITLE
add server::SendResponse::poll_reset to listen for reset streams

### DIFF
--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -51,6 +51,9 @@ pub enum UserError {
 
     /// Request submitted with relative URI.
     MissingUriSchemeAndAuthority,
+
+    /// Calls `SendResponse::poll_reset` after having called `send_response`.
+    PollResetAfterSendResponse,
 }
 
 // ===== impl RecvError =====
@@ -130,6 +133,7 @@ impl error::Error for UserError {
             OverflowedStreamId => "stream ID overflowed",
             MalformedHeaders => "malformed headers",
             MissingUriSchemeAndAuthority => "request URI missing scheme and authority",
+            PollResetAfterSendResponse => "poll_reset after send_response is illegal",
         }
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use self::connection::{Config, Connection};
 pub(crate) use self::error::Error;
 pub(crate) use self::peer::{Peer, Dyn as DynPeer};
 pub(crate) use self::streams::{Key as StreamKey, StreamRef, OpaqueStreamRef, Streams};
-pub(crate) use self::streams::{Prioritized, Open};
+pub(crate) use self::streams::{PollReset, Prioritized, Open};
 
 use codec::Codec;
 

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -11,6 +11,7 @@ mod streams;
 
 pub(crate) use self::prioritize::Prioritized;
 pub(crate) use self::recv::Open;
+pub(crate) use self::send::PollReset;
 pub(crate) use self::store::Key;
 pub(crate) use self::streams::{StreamRef, OpaqueStreamRef, Streams};
 

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -30,7 +30,6 @@ pub(super) struct Send {
 #[derive(Debug)]
 pub(crate) enum PollReset {
     AwaitingHeaders,
-    #[allow(unused)]
     Streaming,
 }
 

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -47,7 +47,7 @@ pub(super) struct Stream {
     pub buffered_send_data: WindowSize,
 
     /// Task tracking additional send capacity (i.e. window updates).
-    pub send_task: Option<task::Task>,
+    send_task: Option<task::Task>,
 
     /// Frames pending for this stream being sent to the socket
     pub pending_send: buffer::Deque,

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -708,7 +708,7 @@ where
             let mut stream = me.store.resolve(*key);
             trace!("poll_pending_open; stream = {:?}", stream.is_pending_open);
             if stream.is_pending_open {
-                stream.send_task = Some(task::current());
+                stream.wait_send();
                 return Ok(Async::NotReady);
             }
         }
@@ -928,6 +928,17 @@ impl<B> StreamRef<B> {
         let mut stream = me.store.resolve(self.opaque.key);
 
         me.actions.send.poll_capacity(&mut stream)
+    }
+
+    /// Request to be notified for if a `RST_STREAM` is received for this stream.
+    pub(crate) fn poll_reset(&mut self) -> Poll<Reason, ::Error> {
+        let mut me = self.opaque.inner.lock().unwrap();
+        let me = &mut *me;
+
+        let mut stream = me.store.resolve(self.opaque.key);
+
+        me.actions.send.poll_reset(&mut stream)
+            .map_err(From::from)
     }
 
     pub(crate) fn key(&self) -> store::Key {

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -931,13 +931,13 @@ impl<B> StreamRef<B> {
     }
 
     /// Request to be notified for if a `RST_STREAM` is received for this stream.
-    pub(crate) fn poll_reset(&mut self) -> Poll<Reason, ::Error> {
+    pub(crate) fn poll_reset(&mut self, mode: proto::PollReset) -> Poll<Reason, ::Error> {
         let mut me = self.opaque.inner.lock().unwrap();
         let me = &mut *me;
 
         let mut stream = me.store.resolve(self.opaque.key);
 
-        me.actions.send.poll_reset(&mut stream)
+        me.actions.send.poll_reset(&mut stream, mode)
             .map_err(From::from)
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -979,8 +979,13 @@ impl<B: IntoBuf> SendResponse<B> {
     ///
     /// If a `RST_STREAM` frame is received for this stream, calling this
     /// method will yield the `Reason` for the reset.
+    ///
+    /// # Error
+    ///
+    /// Calling this method after having called `send_response` will return
+    /// a user error.
     pub fn poll_reset(&mut self) -> Poll<Reason, ::Error> {
-        self.inner.poll_reset()
+        self.inner.poll_reset(proto::PollReset::AwaitingHeaders)
     }
 
     // TODO: Support reserving push promises.

--- a/src/server.rs
+++ b/src/server.rs
@@ -972,6 +972,17 @@ impl<B: IntoBuf> SendResponse<B> {
         self.inner.send_reset(reason)
     }
 
+    /// Polls to be notified when the client resets this stream.
+    ///
+    /// If stream is still open, this returns `Ok(Async::NotReady)`, and
+    /// registers the task to be notified if a `RST_STREAM` is received.
+    ///
+    /// If a `RST_STREAM` frame is received for this stream, calling this
+    /// method will yield the `Reason` for the reset.
+    pub fn poll_reset(&mut self) -> Poll<Reason, ::Error> {
+        self.inner.poll_reset()
+    }
+
     // TODO: Support reserving push promises.
 }
 

--- a/src/share.rs
+++ b/src/share.rs
@@ -319,6 +319,22 @@ impl<B: IntoBuf> SendStream<B> {
     pub fn send_reset(&mut self, reason: Reason) {
         self.inner.send_reset(reason)
     }
+
+    /// Polls to be notified when the client resets this stream.
+    ///
+    /// If stream is still open, this returns `Ok(Async::NotReady)`, and
+    /// registers the task to be notified if a `RST_STREAM` is received.
+    ///
+    /// If a `RST_STREAM` frame is received for this stream, calling this
+    /// method will yield the `Reason` for the reset.
+    ///
+    /// # Error
+    ///
+    /// If connection sees an error, this returns that error instead of a
+    /// `Reason`.
+    pub fn poll_reset(&mut self) -> Poll<Reason, ::Error> {
+        self.inner.poll_reset(proto::PollReset::Streaming)
+    }
 }
 
 // ===== impl RecvStream =====

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -539,7 +539,7 @@ fn poll_reset_io_error() {
 }
 
 #[test]
-fn poll_reset_send_response_is_user_error() {
+fn poll_reset_after_send_response_is_user_error() {
     let _ = ::env_logger::try_init();
     let (io, client) = mock::new();
 
@@ -551,6 +551,15 @@ fn poll_reset_send_response_is_user_error() {
             frames::headers(1)
                 .request("GET", "https://example.com/")
                 .eos()
+        )
+        .recv_frame(
+            frames::headers(1)
+                .response(200)
+        )
+        .recv_frame(
+            // After the error, our server will drop the handles,
+            // meaning we receive a RST_STREAM here.
+            frames::reset(1).cancel()
         )
         .idle_ms(10)
         .close();


### PR DESCRIPTION
Allows for listening for `RST_STREAM`s that may be sent before a `Response` has been generated, and cancel everything.