### PR TITLE
Promote SendRequest::pending to an OpaqueStreamRef.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -223,7 +223,7 @@ pub struct Handshake<T, B: IntoBuf = Bytes> {
 /// [`Error`]: ../struct.Error.html
 pub struct SendRequest<B: IntoBuf> {
     inner: proto::Streams<B::Buf, Peer>,
-    pending: Option<proto::StreamKey>,
+    pending: Option<proto::OpaqueStreamRef>,
 }
 
 /// Returns a `SendRequest` instance once it is ready to send at least one
@@ -568,7 +568,7 @@ where
             .map_err(Into::into)
             .map(|stream| {
                 if stream.is_pending_open() {
-                    self.pending = Some(stream.key());
+                    self.pending = Some(stream.clone_to_opaque());
                 }
 
                 let response = ResponseFuture {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -9,7 +9,7 @@ mod streams;
 pub(crate) use self::connection::{Config, Connection};
 pub(crate) use self::error::Error;
 pub(crate) use self::peer::{Peer, Dyn as DynPeer};
-pub(crate) use self::streams::{Key as StreamKey, StreamRef, OpaqueStreamRef, Streams};
+pub(crate) use self::streams::{StreamRef, OpaqueStreamRef, Streams};
 pub(crate) use self::streams::{PollReset, Prioritized, Open};
 
 use codec::Codec;

--- a/src/proto/streams/mod.rs
+++ b/src/proto/streams/mod.rs
@@ -12,7 +12,6 @@ mod streams;
 pub(crate) use self::prioritize::Prioritized;
 pub(crate) use self::recv::Open;
 pub(crate) use self::send::PollReset;
-pub(crate) use self::store::Key;
 pub(crate) use self::streams::{StreamRef, OpaqueStreamRef, Streams};
 
 use self::buffer::Buffer;

--- a/tests/h2-tests/tests/client_request.rs
+++ b/tests/h2-tests/tests/client_request.rs
@@ -916,6 +916,8 @@ fn notify_on_send_capacity() {
                     assert_eq!(response.status(), StatusCode::OK);
                 }
 
+                poll_fn(|| client.poll_ready()).wait().unwrap();
+
                 done_tx.send(()).unwrap();
             });
 


### PR DESCRIPTION
Because `self.pending` doesn't necessarily get cleaned up in a timely fashion -
rather, only when the user calls `poll_ready()` - it was possible for it to
refer to a stream that has already been closed. This would lead to a panic the
next time that `poll_ready()` was called.

Instead, use an `OpaqueStreamRef`, bumping the refcount.

A change to an existing test is included which demonstrates the issue.