### PR TITLE
Add `stream_id` accessors to public API types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1359,8 +1359,8 @@ impl ResponseFuture {
     /// # Panics
     ///
     /// If the lock on the stream store has been poisoned.
-    pub fn stream_id(&self) -> StreamId {
-        self.inner.stream_id()
+    pub fn stream_id(&self) -> ::StreamId {
+        ::StreamId::from_internal(self.inner.stream_id())
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1353,6 +1353,17 @@ impl Future for ResponseFuture {
     }
 }
 
+impl ResponseFuture {
+    /// Returns the stream ID of the response stream.
+    ///
+    /// # Panics
+    ///
+    /// If the lock on the stream store has been poisoned.
+    pub fn stream_id(&self) -> StreamId {
+        self.inner.stream_id()
+    }
+}
+
 // ===== impl Peer =====
 
 impl Peer {

--- a/src/frame/stream_id.rs
+++ b/src/frame/stream_id.rs
@@ -20,8 +20,10 @@ pub struct StreamIdOverflow;
 const STREAM_ID_MASK: u32 = 1 << 31;
 
 impl StreamId {
+    /// Stream ID 0.
     pub const ZERO: StreamId = StreamId(0);
 
+    /// The maximum allowed stream ID.
     pub const MAX: StreamId = StreamId(u32::MAX >> 1);
 
     /// Parse the stream ID
@@ -49,6 +51,7 @@ impl StreamId {
         id != 0 && id % 2 == 0
     }
 
+    /// Return a new `StreamId` for stream 0.
     #[inline]
     pub fn zero() -> StreamId {
         StreamId::ZERO

--- a/src/frame/stream_id.rs
+++ b/src/frame/stream_id.rs
@@ -1,6 +1,16 @@
 use byteorder::{BigEndian, ByteOrder};
 use std::u32;
 
+/// A stream identifier, as described in [Section 5.1.1] of RFC 7540.
+///
+/// Streams are identified with an unsigned 31-bit integer. Streams
+/// initiated by a client MUST use odd-numbered stream identifiers; those
+/// initiated by the server MUST use even-numbered stream identifiers.  A
+/// stream identifier of zero (0x0) is used for connection control
+/// messages; the stream identifier of zero cannot be used to establish a
+/// new stream.
+///
+/// [Section 5.1.1]: https://tools.ietf.org/html/rfc7540#section-5.1.1
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct StreamId(u32);
 
@@ -25,11 +35,15 @@ impl StreamId {
         (StreamId(unpacked & !STREAM_ID_MASK), flag)
     }
 
+    /// Returns true if this stream ID corresponds to a stream that
+    /// was initiated by the client.
     pub fn is_client_initiated(&self) -> bool {
         let id = self.0;
         id != 0 && id % 2 == 1
     }
 
+    /// Returns true if this stream ID corresponds to a stream that
+    /// was initiated by the server.
     pub fn is_server_initiated(&self) -> bool {
         let id = self.0;
         id != 0 && id % 2 == 0
@@ -40,10 +54,14 @@ impl StreamId {
         StreamId::ZERO
     }
 
+    /// Returns true if this stream ID is zero.
     pub fn is_zero(&self) -> bool {
         self.0 == 0
     }
 
+    /// Returns the next stream ID initiated by the same peer as this stream
+    /// ID, or an error if incrementing this stream ID would overflow the
+    /// maximum.
     pub fn next_id(&self) -> Result<StreamId, StreamIdOverflow> {
         let next = self.0 + 2;
         if next > StreamId::MAX.0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,7 @@ pub mod server;
 mod share;
 
 pub use error::{Error, Reason};
-pub use share::{SendStream, RecvStream, ReleaseCapacity};
-pub use frame::StreamId;
+pub use share::{SendStream, StreamId, RecvStream, ReleaseCapacity};
 
 #[cfg(feature = "unstable")]
 pub use codec::{Codec, RecvError, SendError, UserError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ mod share;
 
 pub use error::{Error, Reason};
 pub use share::{SendStream, RecvStream, ReleaseCapacity};
+pub use frame::StreamId;
 
 #[cfg(feature = "unstable")]
 pub use codec::{Codec, RecvError, SendError, UserError};

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -946,6 +946,10 @@ impl<B> StreamRef<B> {
     {
         self.opaque.clone()
     }
+
+    pub fn stream_id(&self) -> StreamId {
+        self.opaque.stream_id()
+    }
 }
 
 impl<B> Clone for StreamRef<B> {
@@ -1017,6 +1021,13 @@ impl OpaqueStreamRef {
         me.actions
             .recv
             .release_capacity(capacity, &mut stream, &mut me.actions.task)
+    }
+
+    pub fn stream_id(&self) -> StreamId {
+        self.inner.lock()
+            .unwrap()
+            .store[self.key]
+            .id
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -993,8 +993,8 @@ impl<B: IntoBuf> SendResponse<B> {
     /// # Panics
     ///
     /// If the lock on the strean store has been poisoned.
-    pub fn stream_id(&self) -> StreamId {
-        self.inner.stream_id()
+    pub fn stream_id(&self) -> ::StreamId {
+        ::StreamId::from_internal(self.inner.stream_id())
     }
 
     // TODO: Support reserving push promises.

--- a/src/server.rs
+++ b/src/server.rs
@@ -988,6 +988,15 @@ impl<B: IntoBuf> SendResponse<B> {
         self.inner.poll_reset(proto::PollReset::AwaitingHeaders)
     }
 
+    /// Returns the stream ID of the response stream.
+    ///
+    /// # Panics
+    ///
+    /// If the lock on the strean store has been poisoned.
+    pub fn stream_id(&self) -> StreamId {
+        self.inner.stream_id()
+    }
+
     // TODO: Support reserving push promises.
 }
 

--- a/src/share.rs
+++ b/src/share.rs
@@ -335,6 +335,15 @@ impl<B: IntoBuf> SendStream<B> {
     pub fn poll_reset(&mut self) -> Poll<Reason, ::Error> {
         self.inner.poll_reset(proto::PollReset::Streaming)
     }
+
+    /// Returns the stream ID of this `SendStream`.
+    ///
+    /// # Panics
+    ///
+    /// If the lock on the stream store has been poisoned.
+    pub fn stream_id(&self) -> ::StreamId {
+        self.inner.stream_id()
+    }
 }
 
 // ===== impl RecvStream =====
@@ -370,6 +379,15 @@ impl RecvStream {
     pub fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, ::Error> {
         self.inner.inner.poll_trailers().map_err(Into::into)
     }
+
+    /// Returns the stream ID of this stream.
+    ///
+    /// # Panics
+    ///
+    /// If the lock on the stream store has been poisoned.
+    pub fn stream_id(&self) -> ::StreamId {
+        self.inner.stream_id()
+    }
 }
 
 impl futures::Stream for RecvStream {
@@ -394,6 +412,16 @@ impl fmt::Debug for RecvStream {
 impl ReleaseCapacity {
     pub(crate) fn new(inner: proto::OpaqueStreamRef) -> Self {
         ReleaseCapacity { inner }
+    }
+
+    /// Returns the stream ID of the stream whose capacity will
+    /// be released by this `ReleaseCapacity`.
+    ///
+    /// # Panics
+    ///
+    /// If the lock on the stream store has been poisoned.
+    pub fn stream_id(&self) -> ::StreamId {
+        self.inner.stream_id()
     }
 
     /// Release window capacity back to remote stream.

--- a/src/share.rs
+++ b/src/share.rs
@@ -106,7 +106,7 @@ pub struct SendStream<B: IntoBuf> {
 /// new stream.
 ///
 /// [Section 5.1.1]: https://tools.ietf.org/html/rfc7540#section-5.1.1
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct StreamId(u32);
 
 /// Receives the body stream and trailers from the remote peer.


### PR DESCRIPTION
Problem:

Applications may want to access the underlying h2 stream ID for
diagnostics, etc. Stream IDs were not previously exposed in public APIs.

Solution:

The `frame::StreamId` type is now publically exported and has RustDoc
comments. The public API types `SendStream`, `RecvStream`, 
`ReleaseCapacity`, `client::ResponseFuture`, and `server::SendResponse` 
now all have `stream_id` methods which return the stream ID of the 
corresponding stream.

Closes #289.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>