### PR TITLE
Prevent `pending_open` streams from being released.

### DIFF
--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -622,6 +622,13 @@ impl Prioritize {
         }
     }
 
+    pub fn clear_pending_open(&mut self, store: &mut Store, counts: &mut Counts) {
+        while let Some(stream) = self.pending_open.pop(store) {
+            let is_pending_reset = stream.is_pending_reset_expiration();
+            counts.transition_after(stream, is_pending_reset);
+        }
+    }
+
     fn pop_frame<B>(
         &mut self,
         buffer: &mut Buffer<Frame<B>>,

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -417,6 +417,7 @@ impl Send {
     pub fn clear_queues(&mut self, store: &mut Store, counts: &mut Counts) {
         self.prioritize.clear_pending_capacity(store, counts);
         self.prioritize.clear_pending_send(store, counts);
+        self.prioritize.clear_pending_open(store, counts);
     }
 
     pub fn ensure_not_idle(&self, id: StreamId) -> Result<(), Reason> {

--- a/src/proto/streams/stream.rs
+++ b/src/proto/streams/stream.rs
@@ -229,7 +229,7 @@ impl Stream {
             // The stream is not in any queue
             !self.is_pending_send && !self.is_pending_send_capacity &&
             !self.is_pending_accept && !self.is_pending_window_update &&
-            !self.reset_at.is_some()
+            !self.is_pending_open && !self.reset_at.is_some()
     }
 
     /// Returns true when the consumer of the stream has dropped all handles


### PR DESCRIPTION
This fixes a panic that would otherwise occur in some cases. A test
demonstrating said panic is included.