### PR TITLE
fix graceful shutdown to close once idle

### DIFF
--- a/src/proto/go_away.rs
+++ b/src/proto/go_away.rs
@@ -127,6 +127,8 @@ impl GoAway {
                 .expect("invalid GOAWAY frame");
 
             return Ok(Async::Ready(Some(reason)));
+        } else if self.should_close_now() {
+            return Ok(Async::Ready(self.going_away_reason()));
         }
 
         Ok(Async::Ready(None))

--- a/tests/h2-tests/tests/server.rs
+++ b/tests/h2-tests/tests/server.rs
@@ -268,7 +268,7 @@ fn graceful_shutdown() {
         .send_frame(frames::data(7, "").eos())
         .send_frame(frames::data(3, "").eos())
         .recv_frame(frames::headers(3).response(200).eos())
-        .close(); //TODO: closed()?
+        .recv_eof();
 
     let srv = server::handshake(io)
         .expect("handshake")


### PR DESCRIPTION
Prior to this change, after having sent the the GOAWAY capping the last known stream ID, the server would wait until its active streams had finished, and then try to trigger `go_away_now`. However, since the last stream ID and reason were the same, it would prevent sending the duplicate frame, and then loop. This change now notices the new `go_away_now` call, and allows the server to finish.

The tests were adjusted to make sure the client received an EOF, instead of just closing the client in the test. This showed that we weren't doing so, and the change fixes the test again.