### PR TITLE
set deny(warnings) only when cfg(test)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,8 @@
 //! [`client::handshake`]: client/fn.handshake.html
 
 #![doc(html_root_url = "https://docs.rs/h2/0.1.12")]
-#![deny(warnings, missing_debug_implementations, missing_docs)]
+#![deny(missing_debug_implementations, missing_docs)]
+#![cfg_attr(test, deny(warnings))]
 
 #[macro_use]
 extern crate futures;


### PR DESCRIPTION
This should fix building the docs on docs.rs.

Closes #306 