### PR TITLE
Add Reset::INTERNAL_ERROR helper to test support

### DIFF
--- a/tests/h2-support/src/frames.rs
+++ b/tests/h2-support/src/frames.rs
@@ -295,6 +295,11 @@ impl Mock<frame::Reset> {
         let id = self.0.stream_id();
         Mock(frame::Reset::new(id, frame::Reason::CANCEL))
     }
+
+    pub fn internal_error(self) -> Self {
+        let id = self.0.stream_id();
+        Mock(frame::Reset::new(id, frame::Reason::INTERNAL_ERROR))
+    }
 }
 
 impl From<Mock<frame::Reset>> for SendFrame {


### PR DESCRIPTION
I needed this while writing tests for tower-h2.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>