### PR TITLE
Check whether the send side is not idle, not the recv side

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -394,8 +394,7 @@ where
                 );
             } else {
                 me.actions
-                    .send
-                    .ensure_not_idle(id)
+                    .ensure_not_idle(me.counts.peer(), id)
                     .map_err(RecvError::Connection)?;
             }
         }

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -394,7 +394,7 @@ where
                 );
             } else {
                 me.actions
-                    .recv
+                    .send
                     .ensure_not_idle(id)
                     .map_err(RecvError::Connection)?;
             }


### PR DESCRIPTION
We think this fixes #312 -- for window updates, we should be checking against the client-initiated send streams, not the server-initiated recv streams.