### PR TITLE
Update examples to use new Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde = "1.0.0"
 serde_json = "1.0.0"
 
 # Akamai example
-tokio = "0.1"
+tokio = "0.1.8"
 env_logger = { version = "0.5.3", default-features = false }
 rustls = "0.12"
 tokio-rustls = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde = "1.0.0"
 serde_json = "1.0.0"
 
 # Akamai example
-tokio-core = "0.1"
+tokio = "0.1"
 env_logger = { version = "0.5.3", default-features = false }
 rustls = "0.12"
 tokio-rustls = "0.5.0"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,7 +2,7 @@ extern crate env_logger;
 extern crate futures;
 extern crate h2;
 extern crate http;
-extern crate tokio_core;
+extern crate tokio;
 
 use h2::client;
 use h2::RecvStream;
@@ -10,8 +10,7 @@ use h2::RecvStream;
 use futures::*;
 use http::*;
 
-use tokio_core::net::TcpStream;
-use tokio_core::reactor;
+use tokio::net::TcpStream;
 
 struct Process {
     body: RecvStream,
@@ -47,10 +46,7 @@ impl Future for Process {
 pub fn main() {
     let _ = env_logger::try_init();
 
-    let mut core = reactor::Core::new().unwrap();
-    let handle = core.handle();
-
-    let tcp = TcpStream::connect(&"127.0.0.1:5928".parse().unwrap(), &handle);
+    let tcp = TcpStream::connect(&"127.0.0.1:5928".parse().unwrap());
 
     let tcp = tcp.then(|res| {
         let tcp = res.unwrap();
@@ -74,7 +70,7 @@ pub fn main() {
             stream.send_trailers(trailers).unwrap();
 
             // Spawn a task to run the conn...
-            handle.spawn(h2.map_err(|e| println!("GOT ERR={:?}", e)));
+            tokio::spawn(h2.map_err(|e| println!("GOT ERR={:?}", e)));
 
             response
                 .and_then(|response| {
@@ -93,5 +89,5 @@ pub fn main() {
                 })
         });
 
-    core.run(tcp).unwrap();
+    tokio::run(tcp);
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -68,27 +68,21 @@
 //! extern crate futures;
 //! extern crate h2;
 //! extern crate http;
-//! extern crate tokio_core;
+//! extern crate tokio;
 //!
 //! use h2::client;
 //!
 //! use futures::*;
-//! # use futures::future::ok;
 //! use http::*;
 //!
-//! use tokio_core::net::TcpStream;
-//! use tokio_core::reactor;
+//! use tokio::net::TcpStream;
 //!
 //! pub fn main() {
-//!     let mut core = reactor::Core::new().unwrap();
-//!     let handle = core.handle();
-//!
 //!     let addr = "127.0.0.1:5928".parse().unwrap();
 //!
-//!     core.run({
-//! # let _ =
+//!     tokio::run(
 //!         // Establish TCP connection to the server.
-//!         TcpStream::connect(&addr, &handle)
+//!         TcpStream::connect(&addr)
 //!             .map_err(|_| {
 //!                 panic!("failed to establish TCP connection")
 //!             })
@@ -98,7 +92,7 @@
 //!                     .map_err(|_| panic!("HTTP/2.0 connection failed"));
 //!
 //!                 // Spawn a new task to drive the connection state
-//!                 handle.spawn(connection);
+//!                 tokio::spawn(connection);
 //!
 //!                 // Wait until the `SendRequest` handle has available
 //!                 // capacity.
@@ -139,9 +133,8 @@
 //!                     })
 //!                 })
 //!             })
-//! # ;
-//! # ok::<_, ()>(())
-//!     }).ok().expect("failed to perform HTTP/2.0 request");
+//!             .map_err(|e| panic!("failed to perform HTTP/2.0 request: {:?}", e))
+//!     )
 //! }
 //! ```
 //!

--- a/src/server.rs
+++ b/src/server.rs
@@ -67,27 +67,23 @@
 //! extern crate futures;
 //! extern crate h2;
 //! extern crate http;
-//! extern crate tokio_core;
+//! extern crate tokio;
 //!
 //! use futures::{Future, Stream};
 //! # use futures::future::ok;
 //! use h2::server;
 //! use http::{Response, StatusCode};
-//! use tokio_core::reactor;
-//! use tokio_core::net::TcpListener;
+//! use tokio::net::TcpListener;
 //!
 //! pub fn main () {
-//!     let mut core = reactor::Core::new().unwrap();
-//!     let handle = core.handle();
-//!
 //!     let addr = "127.0.0.1:5928".parse().unwrap();
-//!     let listener = TcpListener::bind(&addr, &handle).unwrap();
+//!     let listener = TcpListener::bind(&addr,).unwrap();
 //!
-//!     core.run({
+//!     tokio::run({
 //!         // Accept all incoming TCP connections.
-//!         listener.incoming().for_each(move |(socket, _)| {
+//!         listener.incoming().for_each(move |socket| {
 //!             // Spawn a new task to process each connection.
-//!             handle.spawn({
+//!             tokio::spawn({
 //!                 // Start the HTTP/2.0 connection handshake
 //!                 server::handshake(socket)
 //!                     .and_then(|h2| {
@@ -114,8 +110,8 @@
 //!
 //!             Ok(())
 //!         })
-//!         # .select(ok(()))
-//!     }).ok().expect("failed to run HTTP/2.0 server");
+//!         .map_err(|e| panic!("failed to run HTTP/2.0 server: {:?}", e))
+//!     });
 //! }
 //! ```
 //!

--- a/src/server.rs
+++ b/src/server.rs
@@ -111,6 +111,7 @@
 //!             Ok(())
 //!         })
 //!         .map_err(|e| panic!("failed to run HTTP/2.0 server: {:?}", e))
+//!  #      .select(ok(())).map(|_|()).map_err(|_|())
 //!     });
 //! }
 //! ```


### PR DESCRIPTION
The old `tokio-core` crate is deprecated in favour of the `tokio` crate,
which also provides the new multithreaded Tokio runtime. Although `h2`
is generic over the runtime, the examples do depend on `tokio`. 

This branch update the example code to use the new `tokio` library
rather than `tokio-core`.

For the most part, this was pretty trivial --- simply replacing
`handle.spawn(...)` with `tokio::spawn(...)` and `core.run(...)` with
`tokio::run(...)`. There were a couple of cases where error and item
types from spawned futures had to be mapped to `(), ()`. Alternatively,
this could have been avoided by using the single-threaded runtime and
calling `block_on` instead to await the value of those futures, but I
thought it was better to reduce the amount of tokio-specific code in the
examples.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>