### PR TITLE
Reassign capacity from reset streams.

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -320,17 +320,6 @@ impl Send {
         Ok(())
     }
 
-    pub fn recv_reset<B>(
-        &mut self,
-        buffer: &mut Buffer<Frame<B>>,
-        stream: &mut store::Ptr,
-        counts: &mut Counts,
-    ) {
-        // Clear all pending outbound frames
-        self.prioritize.clear_queue(buffer, stream);
-        self.prioritize.reclaim_all_capacity(stream, counts);
-    }
-
     pub fn recv_err<B>(
         &mut self,
         buffer: &mut Buffer<Frame<B>>,

--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -323,10 +323,12 @@ impl Send {
     pub fn recv_reset<B>(
         &mut self,
         buffer: &mut Buffer<Frame<B>>,
-        stream: &mut store::Ptr
+        stream: &mut store::Ptr,
+        counts: &mut Counts,
     ) {
         // Clear all pending outbound frames
         self.prioritize.clear_queue(buffer, stream);
+        self.prioritize.reclaim_all_capacity(stream, counts);
     }
 
     pub fn recv_err<B>(

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -284,9 +284,9 @@ where
 
         let actions = &mut me.actions;
 
-        me.counts.transition(stream, |_, stream| {
+        me.counts.transition(stream, |counts, stream| {
             actions.recv.recv_reset(frame, stream);
-            actions.send.recv_reset(send_buffer, stream);
+            actions.send.recv_reset(send_buffer, stream, counts);
             assert!(stream.state.is_closed());
             Ok(())
         })

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -286,7 +286,7 @@ where
 
         me.counts.transition(stream, |counts, stream| {
             actions.recv.recv_reset(frame, stream);
-            actions.send.recv_reset(send_buffer, stream, counts);
+            actions.send.recv_err(send_buffer, stream, counts);
             assert!(stream.state.is_closed());
             Ok(())
         })


### PR DESCRIPTION
I believe this was an oversight - a stream that is reset can still have some
capacity assigned to it (e.g. if said capacity was assigned in the same poll as
the reset), which should be redistributed.

Note that `Send::recv_reset` is now identical to `Send::recv_err`; I'm not sure if they should be unified.