### PR TITLE
Disable length_delimited deprecation warning.

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,3 +1,6 @@
+// Until tokio-rs/tokio#680 is fixed
+#![allow(deprecated)]
+
 mod error;
 mod framed_read;
 mod framed_write;


### PR DESCRIPTION
Until tokio-rs/tokio#680 is resolved, we should allow using deprecated
APIs in the codec module.