### PR TITLE
Fix client connection deadlock [closes #326]

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -748,16 +748,8 @@ where
     }
 
     pub fn has_streams_or_other_references(&self) -> bool {
-        if Arc::strong_count(&self.inner) > 1 {
-            return true;
-        }
-
-        if Arc::strong_count(&self.send_buffer) > 1 {
-            return true;
-        }
-
         let me = self.inner.lock().unwrap();
-        me.counts.has_streams()
+        me.store.num_active_streams() > 0 || me.counts.has_streams()
     }
 
     #[cfg(feature = "unstable")]


### PR DESCRIPTION
I think I'm starting to get a picture of the problem, here. (Please correct me if I'm wrong.)

`share::RecvStream` holds a `streams::OpaqueStreamRef` (via `share::ReleaseCapacity`). The `OpaqueStreamRef` is one of the structs that can hold a reference on the `Arc`. The other struct is `streams::StreamRef` (which in turn has an inner `OpaqueStreamRef`).

Here's an ASCII art diagram showing the hierarchy (as I understand it):

```
Process
└── share::RecvStream
    └── share::ReleaseCapacity
        └── streams::OpaqueStreamRef
            └── streams::Streams

client.handshake
└── client::Builder
    └── client::Handshake
        └── client::Connection
            └── proto::Connection
                └── streams::Streams
```

`Process` is a struct in the client example. `streams::Streams.has_streams_or_other_references` is where `Arc::strong_count`is called: https://github.com/carllerche/h2/blob/c7d4182ffec23bc1f508a62bb59a9c286fdc888a/src/proto/streams/streams.rs#L750-L761

Commenting these checks does indeed prevent the hang...

The race occurs when the `proto::Connection` future is polled prior to the `OpaqueStreamRef` being fully dropped. This happens because there are two futures in the client example; `client::Connection` and `Process` that both share a reference to the `streams::Streams`. Which means that success depends on the order which the two futures are polled.

From this perspective, I looked into how `proto::Connection` gets woken up, and it simply happens here when the `OpaqueStreamRef` is dropped: https://github.com/carllerche/h2/blob/c7d4182ffec23bc1f508a62bb59a9c286fdc888a/src/proto/streams/streams.rs#L1111-L1119

So the question I had, seeing this condition, is how can I check if all streams are closed on the connection? Well, this looks relevant: https://github.com/carllerche/h2/blob/cf62b783e0bfe7b183cdef78874c5ca6e417c59e/src/proto/streams/store.rs#L196-L198

And the patch works!

I don't know of a good way to test this, other than the STR in https://github.com/carllerche/h2/issues/326#issuecomment-441820232 ... Perhaps creating the two (or more) futures and polling them in deterministic order (instead of on the default tokio runtime) could surface the case where `proto::Connection.go_away.should_close_on_idle` returns false. But I can't see an obvious way to set it up without a large test fixture and set of mocks.

Because I can't deterministically test it, I honestly don't know if this is the right way to address the issue...