### PR TITLE
Fix race in stream ref count

### DIFF
--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -764,7 +764,7 @@ where
         }
 
         let me = self.inner.lock().unwrap();
-        me.counts.has_streams() || me.refs > 1
+        me.counts.has_streams() || me.refs > 0
     }
 
     #[cfg(feature = "unstable")]

--- a/src/proto/streams/streams.rs
+++ b/src/proto/streams/streams.rs
@@ -758,11 +758,6 @@ where
     }
 
     pub fn has_streams_or_other_references(&self) -> bool {
-
-        if Arc::strong_count(&self.send_buffer) > 1 {
-            return true;
-        }
-
         let me = self.inner.lock().unwrap();
         me.counts.has_streams() || me.refs > 0
     }

--- a/tests/h2-tests/Cargo.toml
+++ b/tests/h2-tests/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 [dev-dependencies]
 h2-support = { path = "../h2-support" }
 log = "0.4.1"
+tokio = "0.1.8"

--- a/tests/h2-tests/tests/hammer.rs
+++ b/tests/h2-tests/tests/hammer.rs
@@ -1,0 +1,165 @@
+extern crate tokio;
+#[macro_use]
+extern crate h2_support;
+
+use h2_support::prelude::*;
+use h2_support::futures::{Async, Poll};
+
+use tokio::net::{TcpListener, TcpStream};
+use std::{net::SocketAddr, thread, sync::{atomic::{AtomicUsize, Ordering}, Arc}};
+
+struct Server {
+    addr: SocketAddr,
+    reqs: Arc<AtomicUsize>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl Server {
+    fn serve<F>(mk_data: F) -> Self
+    where
+        F: Fn() -> Bytes,
+        F: Send + Sync + 'static,
+    {
+        let mk_data = Arc::new(mk_data);
+
+        let listener = TcpListener::bind(&SocketAddr::from(([127, 0, 0, 1], 0))).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let reqs = Arc::new(AtomicUsize::new(0));
+        let reqs2 = reqs.clone();
+        let join = thread::spawn(move || {
+            let server = listener.incoming().for_each(move |socket| {
+                let reqs = reqs2.clone();
+                let mk_data = mk_data.clone();
+                let connection = server::handshake(socket)
+                    .and_then(move |conn| {
+                        conn.for_each(move |(_, mut respond)| {
+                            reqs.fetch_add(1, Ordering::Release);
+                            let response = Response::builder().status(StatusCode::OK).body(()).unwrap();
+                            let mut send = respond.send_response(response, false)?;
+                            send.send_data(mk_data(), true).map(|_|())
+                        })
+                    })
+                    .map_err(|e| eprintln!("serve conn error: {:?}", e));
+
+                tokio::spawn(Box::new(connection));
+                Ok(())
+            })
+            .map_err(|e| eprintln!("serve error: {:?}", e));
+
+            tokio::run(server);
+        });
+
+        Self {
+            addr,
+            join: Some(join),
+            reqs
+        }
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr.clone()
+    }
+
+    fn expect_join(&mut self) {
+        self.join.take()
+            .expect("can't join twice")
+            .join()
+            .expect("join")
+    }
+
+    fn request_count(&self) -> usize {
+        self.reqs.load(Ordering::Acquire)
+    }
+}
+
+
+struct Process {
+    body: RecvStream,
+    trailers: bool,
+}
+
+impl Future for Process {
+    type Item = ();
+    type Error = h2::Error;
+
+    fn poll(&mut self) -> Poll<(), h2::Error> {
+        loop {
+            if self.trailers {
+                return match self.body.poll_trailers()? {
+                    Async::NotReady => Ok(Async::NotReady),
+                    Async::Ready(_) => Ok(().into()),
+                };
+            } else {
+                match self.body.poll()? {
+                    Async::NotReady => return Ok(Async::NotReady),
+                    Async::Ready(None) => {
+                        self.trailers = true;
+                    },
+                    _ => {},
+                }
+            }
+        }
+    }
+}
+
+
+#[test]
+fn hammer_client_concurrency() {
+    // This reproduces issue #326.
+    const N: usize = 5000;
+
+    let mut server = Server::serve(|| Bytes::from_static(b"hello world!"));
+
+    let addr = server.addr();
+    let rsps = Arc::new(AtomicUsize::new(0));
+    let rsps2 = rsps.clone();
+
+    let client = thread::spawn(move || {
+        let rsps = rsps2;
+        for _ in 0..N {
+            let rsps = rsps.clone();
+            let tcp = TcpStream::connect(&addr);
+            let tcp = tcp.then(|res| {
+                let tcp = res.unwrap();
+                client::handshake(tcp)
+            }).then(move |res| {
+                    print!("sending");
+                    let rsps = rsps;
+                    let (mut client, h2) = res.unwrap();
+                    let request = Request::builder()
+                        .uri("https://http2.akamai.com/")
+                        .body(())
+                        .unwrap();
+
+                    let (response, mut stream) = client.send_request(request, false).unwrap();
+                    stream.send_trailers(HeaderMap::new()).unwrap();
+
+                    tokio::spawn(h2.map_err(|e| panic!("client conn error: {:?}", e)));
+
+                    response
+                        .and_then(|response| {
+                            let (_, body) = response.into_parts();
+
+                            Process {
+                                body,
+                                trailers: false,
+                            }
+                        })
+                        .map_err(|e| {
+                            panic!("client error: {:?}", e);
+                        })
+                        .map(move |_| {
+                            println!(" {}...done", rsps.fetch_add(1, Ordering::Release));
+                        })
+                });
+
+            tokio::run(tcp);
+        }
+        println!("all done");
+    });
+
+    client.join().expect("client thread");
+
+    assert_eq!(N, rsps.load(Ordering::Acquire));
+    assert_eq!(N, server.request_count());
+}


### PR DESCRIPTION
Currently, there is a race condition that occurs when
`Arc::strong_count` is used to detect whether client handles have been
dropped and a connection could shut down. If the connection manager's
task is notified before the arc ref is dropped, it will see that the ref
count is greater than 1 and go back to sleep, resulting in deadlock.

This branch solves the race by manually counting the number of
`StreamRef`s inside the lock on the shared state, rather than relying on
the `Arc` ref count. I've included a hammer test based on the
reproduction described in #326, and confirmed that it hangs on master
but runs to completion on this branch.

Fixes #326

Signed-off-by: Eliza Weisman <eliza@buoyant.io>