### PR TITLE
Fixed incorrect order of arguments in send_reset trace.

### DIFF
--- a/src/proto/streams/send.rs
+++ b/src/proto/streams/send.rs
@@ -128,8 +128,8 @@ impl Send {
              is_reset={:?}; is_closed={:?}; pending_send.is_empty={:?}; \
              state={:?} \
             ",
-            stream.id,
             reason,
+            stream.id,
             is_reset,
             is_closed,
             is_empty,


### PR DESCRIPTION
This is a low-profile bug, so I'm not creating an issue for it.