### PR TITLE
Loosen bounds on Handshake struct

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -187,7 +187,7 @@ use std::usize;
 ///
 /// [module]: index.html
 #[must_use = "futures do nothing unless polled"]
-pub struct Handshake<T, B: IntoBuf = Bytes> {
+pub struct Handshake<T, B = Bytes> {
     builder: Builder,
     inner: WriteAll<T, &'static [u8]>,
     _marker: PhantomData<B>,


### PR DESCRIPTION
Simply declaring the `Handshake` in another type shouldn't require `T: IntoBuf`...